### PR TITLE
Fix mute toggle (M key)

### DIFF
--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -426,10 +426,10 @@ ipcMain.handle('mpv-volume', async (_event, volume: number) => {
   }
 });
 
-ipcMain.handle('mpv-mute', async (_event, mute: boolean) => {
+ipcMain.handle('mpv-toggle-mute', async () => {
   if (!mpvSocket) return { error: 'mpv not initialized' };
   try {
-    await sendMpvCommand('set_property', ['mute', mute ? 'yes' : 'no']);
+    await sendMpvCommand('cycle', ['mute']);
     return { success: true };
   } catch (error) {
     return { error: error instanceof Error ? error.message : 'Unknown error' };

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -22,7 +22,7 @@ export interface MpvApi {
   togglePause: () => Promise<MpvResult>;
   stop: () => Promise<MpvResult>;
   setVolume: (volume: number) => Promise<MpvResult>;
-  mute: (mute: boolean) => Promise<MpvResult>;
+  toggleMute: () => Promise<MpvResult>;
   seek: (seconds: number) => Promise<MpvResult>;
   getStatus: () => Promise<MpvStatus>;
   onReady: (callback: (ready: boolean) => void) => void;
@@ -90,7 +90,7 @@ contextBridge.exposeInMainWorld('mpv', {
   togglePause: () => ipcRenderer.invoke('mpv-toggle-pause'),
   stop: () => ipcRenderer.invoke('mpv-stop'),
   setVolume: (volume: number) => ipcRenderer.invoke('mpv-volume', volume),
-  mute: (mute: boolean) => ipcRenderer.invoke('mpv-mute', mute),
+  toggleMute: () => ipcRenderer.invoke('mpv-toggle-mute'),
   seek: (seconds: number) => ipcRenderer.invoke('mpv-seek', seconds),
   getStatus: () => ipcRenderer.invoke('mpv-get-status'),
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -117,8 +117,8 @@ function App() {
 
   const handleToggleMute = async () => {
     if (!window.mpv) return;
-    await window.mpv.mute(!muted);
-    setMuted(!muted);
+    await window.mpv.toggleMute();
+    // UI state updated via mpv status callback
   };
 
   const handleStop = async () => {

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -20,7 +20,7 @@ export interface MpvApi {
   togglePause: () => Promise<MpvResult>;
   stop: () => Promise<MpvResult>;
   setVolume: (volume: number) => Promise<MpvResult>;
-  mute: (mute: boolean) => Promise<MpvResult>;
+  toggleMute: () => Promise<MpvResult>;
   seek: (seconds: number) => Promise<MpvResult>;
   getStatus: () => Promise<MpvStatus>;
   onReady: (callback: (ready: boolean) => void) => void;


### PR DESCRIPTION
## Summary
- Fix M key only muting but not unmuting due to race condition
- Use mpv's native `cycle mute` command instead of `set_property`
- Remove unused `mute(boolean)` API

## Test plan
- [ ] Press M to mute - sound should mute, icon should update
- [ ] Press M again to unmute - sound should return, icon should update
- [ ] Click mute button in NowPlayingBar - should toggle correctly