### PR TITLE
Release v0.5.3 — macOS code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,14 @@ jobs:
 
       - name: Build Electron app
         run: pnpm dist:${{ matrix.platform }} --publish never
+        env:
+          # macOS code signing
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MAC_CERTS || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MAC_CERTS_PASSWORD || '' }}
+          # macOS notarization
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.3] - 2026-02-19
+
+### Added
+- macOS code signing and notarization — builds are now signed with Developer ID Application certificate and notarized via Apple, eliminating Gatekeeper warnings and enabling auto-update
+
+### Changed
+- Release workflow passes signing credentials to macOS build via GitHub Secrets
+- Hardened runtime enabled with entitlements for native addon compatibility
+
 ## [0.5.2] - 2026-02-18
 
 ### Improved

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtltv",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -64,6 +64,11 @@ mac:
   icon: assets/sbtltv-logo-white.png
   artifactName: ${productName}-${version}-mac-${arch}.${ext}
   category: public.app-category.entertainment
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: entitlements.mac.plist
+  entitlementsInherit: entitlements.mac.plist
+  notarize: true
 
 dmg:
   contents:

--- a/packages/electron/entitlements.mac.plist
+++ b/packages/electron/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {


### PR DESCRIPTION
## Summary
- macOS code signing and notarization via Developer ID Application certificate
- Hardened runtime entitlements for native addon compatibility
- Release workflow updated with signing secrets

## Test plan
- [x] Prerelease `v0.5.3-signing-test` built and signed successfully
- [ ] Auto-update from v0.5.2 → v0.5.3 on macOS