### PR TITLE
fix: M3U channels in multiple groups

### DIFF
--- a/packages/local-adapter/src/m3u-parser.ts
+++ b/packages/local-adapter/src/m3u-parser.ts
@@ -77,18 +77,28 @@ export function parseM3U(content: string, sourceId: string): M3UParseResult {
       }
 
       // Create channel with stable hash-based ID (survives resyncs)
-      const channel: Channel = {
-        stream_id: `${sourceId}_${stableHash(displayName + '|' + line)}`,
-        name: displayName,
-        stream_icon: currentMetadata.tvgLogo || '',
-        epg_channel_id: currentMetadata.tvgId || '',
-        category_ids: categoryId ? [categoryId] : [],
-        direct_url: line,
-        source_id: sourceId,
-        ...(currentMetadata.tvgChno !== null && { channel_num: currentMetadata.tvgChno }),
-      };
+      const streamId = `${sourceId}_${stableHash(displayName + '|' + line)}`;
 
-      channels.push(channel);
+      // If this stream already exists (same channel in multiple groups),
+      // merge category_ids instead of creating a duplicate
+      const existing = channels.find(ch => ch.stream_id === streamId);
+      if (existing) {
+        if (categoryId && !existing.category_ids.includes(categoryId)) {
+          existing.category_ids.push(categoryId);
+        }
+      } else {
+        channels.push({
+          stream_id: streamId,
+          name: displayName,
+          stream_icon: currentMetadata.tvgLogo || '',
+          epg_channel_id: currentMetadata.tvgId || '',
+          category_ids: categoryId ? [categoryId] : [],
+          direct_url: line,
+          source_id: sourceId,
+          ...(currentMetadata.tvgChno !== null && { channel_num: currentMetadata.tvgChno }),
+        });
+      }
+
       currentMetadata = null;
     }
   }

--- a/packages/ui/src/services/m3u-parser.test.ts
+++ b/packages/ui/src/services/m3u-parser.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { parseM3U } from '@sbtltv/local-adapter';
+
+const SOURCE_ID = 'test-source';
+
+/** Helper to build a minimal M3U string */
+function m3u(...entries: { name: string; group?: string; url: string; logo?: string; tvgId?: string; chno?: number }[]): string {
+  const lines = ['#EXTM3U'];
+  for (const e of entries) {
+    const attrs = [
+      e.group ? `group-title="${e.group}"` : '',
+      e.logo ? `tvg-logo="${e.logo}"` : '',
+      e.tvgId ? `tvg-id="${e.tvgId}"` : '',
+      e.chno !== undefined ? `tvg-chno="${e.chno}"` : '',
+    ].filter(Boolean).join(' ');
+    lines.push(`#EXTINF:-1 ${attrs},${e.name}`);
+    lines.push(e.url);
+  }
+  return lines.join('\n');
+}
+
+describe('parseM3U', () => {
+  it('parses a basic channel', () => {
+    const result = parseM3U(m3u({ name: 'CNN', group: 'News', url: 'http://example.com/cnn' }), SOURCE_ID);
+
+    expect(result.channels).toHaveLength(1);
+    expect(result.channels[0].name).toBe('CNN');
+    expect(result.channels[0].direct_url).toBe('http://example.com/cnn');
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0].category_name).toBe('News');
+  });
+
+  it('creates separate channels for different streams', () => {
+    const result = parseM3U(m3u(
+      { name: 'CNN', group: 'News', url: 'http://example.com/cnn' },
+      { name: 'BBC', group: 'News', url: 'http://example.com/bbc' },
+    ), SOURCE_ID);
+
+    expect(result.channels).toHaveLength(2);
+    expect(result.channels[0].name).toBe('CNN');
+    expect(result.channels[1].name).toBe('BBC');
+  });
+
+  describe('duplicate streams in multiple groups', () => {
+    it('merges category_ids when same channel appears in multiple groups', () => {
+      const result = parseM3U(m3u(
+        { name: 'CNN', group: 'News', url: 'http://example.com/cnn' },
+        { name: 'CNN', group: '1_FAVORITES', url: 'http://example.com/cnn' },
+      ), SOURCE_ID);
+
+      // Should be ONE channel, not two
+      expect(result.channels).toHaveLength(1);
+      expect(result.channels[0].name).toBe('CNN');
+      // Should have both categories
+      expect(result.channels[0].category_ids).toHaveLength(2);
+
+      // Both categories should exist
+      const catNames = result.categories.map(c => c.category_name).sort();
+      expect(catNames).toEqual(['1_FAVORITES', 'News']);
+    });
+
+    it('handles channel in three or more groups', () => {
+      const result = parseM3U(m3u(
+        { name: 'ESPN', group: 'Sports', url: 'http://example.com/espn' },
+        { name: 'ESPN', group: '1_FAVORITES', url: 'http://example.com/espn' },
+        { name: 'ESPN', group: '2_SPORTS', url: 'http://example.com/espn' },
+      ), SOURCE_ID);
+
+      expect(result.channels).toHaveLength(1);
+      expect(result.channels[0].category_ids).toHaveLength(3);
+      expect(result.categories).toHaveLength(3);
+    });
+
+    it('does not duplicate category_ids if same group listed twice', () => {
+      const result = parseM3U(m3u(
+        { name: 'CNN', group: 'News', url: 'http://example.com/cnn' },
+        { name: 'CNN', group: 'News', url: 'http://example.com/cnn' },
+      ), SOURCE_ID);
+
+      expect(result.channels).toHaveLength(1);
+      // Same category — should not duplicate
+      expect(result.channels[0].category_ids).toHaveLength(1);
+    });
+
+    it('treats different URLs as different channels even with same name', () => {
+      const result = parseM3U(m3u(
+        { name: 'CNN', group: 'News', url: 'http://example.com/cnn-hd' },
+        { name: 'CNN', group: 'News', url: 'http://example.com/cnn-sd' },
+      ), SOURCE_ID);
+
+      // Different URLs = different channels (different stream_ids)
+      expect(result.channels).toHaveLength(2);
+    });
+  });
+
+  it('handles channels with no group', () => {
+    const result = parseM3U(m3u(
+      { name: 'Random', url: 'http://example.com/random' },
+    ), SOURCE_ID);
+
+    expect(result.channels).toHaveLength(1);
+    expect(result.channels[0].category_ids).toEqual([]);
+    expect(result.categories).toHaveLength(0);
+  });
+
+  it('handles duplicate of a channel with no group into a group', () => {
+    const result = parseM3U(m3u(
+      { name: 'CNN', url: 'http://example.com/cnn' },
+      { name: 'CNN', group: 'Favorites', url: 'http://example.com/cnn' },
+    ), SOURCE_ID);
+
+    expect(result.channels).toHaveLength(1);
+    // Should pick up the Favorites category
+    expect(result.channels[0].category_ids).toHaveLength(1);
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0].category_name).toBe('Favorites');
+  });
+});


### PR DESCRIPTION
## Summary
- M3U parser now merges `category_ids` when the same channel appears in multiple groups (e.g. duplicated into custom favorites via IPTVEditor)
- Previously the last group overwrote earlier ones, so channels disappeared from their original categories

## Test plan
- [x] 8 new vitest tests covering: merge, 3+ groups, duplicate group, different URLs same name, no group, no group → group