### PR TITLE
fix: macOS auto-update quarantine permission error

### DIFF
--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -17,6 +17,7 @@ files:
   - assets/**/*
   - "!**/*.ts"
   - "!**/tsconfig.json"
+  - "!**/deps/**"
 
 # Unpack native addons and their dylib/dll deps from the asar archive.
 # Electron auto-unpacks .node files, but the co-located dylibs need

--- a/packages/mpv-texture/scripts/setup-mpv-mac.sh
+++ b/packages/mpv-texture/scripts/setup-mpv-mac.sh
@@ -49,6 +49,7 @@ echo "Source dylib: $MPV_DYLIB"
 
 # Copy libmpv
 cp "$MPV_DYLIB" "$DEPS_DIR/libmpv.dylib"
+chmod 755 "$DEPS_DIR/libmpv.dylib"
 
 # Rewrite the dylib's install_name to @rpath/libmpv.dylib
 # This is critical: when node-gyp links mpv_texture.node against this dylib,


### PR DESCRIPTION
## Summary
- Squirrel.Mac's ShipIt fails to install updates because it can't remove the quarantine xattr from a read-only `libmpv.dylib` in `app.asar.unpacked`
- The file at `deps/mpv/macos/libmpv.dylib` is a **build-time** dependency (used for linking during `npm run build:native`) that was leaking into the packaged app via the `asarUnpack: "**/*.dylib"` rule
- The **runtime** copy in `extraResources/mpv/` already has correct 755 permissions from `bundle-dylibs-mac.sh`

### Changes
- **`electron-builder.yml`**: Exclude `**/deps/**` from packaged files — headers and source dylib are build-time only
- **`setup-mpv-mac.sh`**: `chmod 755` after copying libmpv.dylib from Homebrew (belt-and-suspenders)

### Root cause (from ShipIt logs)
```
Installation error: Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"
  Couldn't remove quarantine attribute from ".../app.asar.unpacked/node_modules/@sbtltv/mpv-texture/deps/mpv/macos/libmpv.dylib"
  This most likely means the file is read-only.
```

## Test plan
- [ ] Build macOS release, verify `deps/` directory is not in the app bundle
- [ ] Verify `extraResources/mpv/libmpv.dylib` still present with 755 permissions
- [ ] Install old version, publish new release, confirm auto-update completes successfully
- [ ] Verify app launches correctly after update (native addon loads from extraResources)