### PR TITLE
feat: EPG channel matching with external EPG sources

### DIFF
--- a/packages/electron/src/epg-parse-worker.ts
+++ b/packages/electron/src/epg-parse-worker.ts
@@ -1,8 +1,12 @@
 /**
- * EPG Parse Worker Thread
- * Stream-parses XMLTV from a file — constant memory usage, handles any file size.
- * If provider channels are given, matches them first (quick channel scan) then
- * only parses matching programmes on the second pass.
+ * EPG Parse Worker Thread (Node.js Worker Thread in main process)
+ *
+ * Uses a worker thread (not web worker) because gzipped EPG files need native
+ * fs/zlib for streaming decompression — unavailable in browser web workers.
+ *
+ * Stream-parses XMLTV from a file — constant memory, handles any file size.
+ * Two-phase parsing: Phase 1 scans only <channel> elements to build a matched
+ * ID set, Phase 2 uses that set to skip ~90% of <programme> data.
  */
 import { parentPort, workerData } from 'worker_threads';
 import { createReadStream, statSync } from 'fs';
@@ -11,14 +15,18 @@ interface EpgChannel { id: string; displayNames: string[]; }
 interface EpgProgram { channel_id: string; title: string; description: string; start: string; stop: string; }
 interface ProviderChannel { epg_channel_id: string; name: string; stream_id: string; }
 
-// ---- Matching helpers (same logic as epg-matcher.ts) ----
+function workerLog(msg: string) {
+  parentPort?.postMessage({ type: 'log', message: msg });
+}
+
+// ---- Matching helpers (duplicated from epg-matcher.ts) ----
+// Worker thread runs in Node.js main process and can't import from the
+// renderer-side UI package. Keep these in sync with epg-matcher.ts manually.
 
 function normalize(name: string): string {
   let s = name;
   s = s.replace(/^(USA?|UK|CA|AU|NZ|FR|DE|ES|IT|PT|NL|BE|AT|CH|IE|IN)\s*[:\-|]?\s*/i, '');
-  while (/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i.test(s)) {
-    s = s.replace(/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i, '');
-  }
+  s = s.replace(/([\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*))+\s*$/i, '');
   s = s.toLowerCase();
   s = s.replace(/&/g, 'and').replace(/\+/g, 'plus');
   return s.replace(/[^a-z0-9]/g, '');
@@ -27,7 +35,9 @@ function normalize(name: string): string {
 function normalizeLooser(name: string): string {
   let s = normalize(name);
   s = s.replace(/^the/, '');
-  s = s.replace(/(channel|network|television|tv)$/, '');
+  s = s.replace(/(channel|network|television)$/, '');
+  // Only strip trailing "tv" if preceded by 3+ chars (avoid mangling acronyms like MTV, CTV, ATV)
+  s = s.replace(/(?<=.{3})tv$/, '');
   return s;
 }
 
@@ -38,7 +48,7 @@ function extractCodes(epgId: string): string[] {
 }
 
 function slugify(id: string): string {
-  return id.replace(/\.\w{2,3}$/, '').replace(/\([^)]*\)/, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  return id.replace(/\.\w{2,3}$/, '').replace(/\([^)]*\)/g, '').toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 function stripTld(id: string): string {
@@ -50,7 +60,8 @@ function decodeEntities(s: string): string {
   return s
     .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, c) => String.fromCharCode(parseInt(c, 10)));
+    .replace(/&#(\d+);/g, (_, c) => String.fromCharCode(parseInt(c, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, c) => String.fromCharCode(parseInt(c, 16)));
 }
 
 function parseDate(d: string): string | null {
@@ -76,6 +87,8 @@ function buildMatchedXmltvIds(xmltvChannels: EpgChannel[], providerChannels: Pro
     exactMap.set(xch.id, xch.id);
     for (const code of extractCodes(xch.id)) {
       codeMap.set(code, xch.id);
+      // US/CA local stations use DT (digital television) suffix in XMLTV (e.g. "wabcdt"),
+      // but providers use bare call signs ("wabc"). Map base call to catch these.
       const dtMatch = code.match(/^(.+?)dt(\d?)$/);
       if (dtMatch) {
         const baseCall = dtMatch[1];
@@ -100,6 +113,7 @@ function buildMatchedXmltvIds(xmltvChannels: EpgChannel[], providerChannels: Pro
   }
 
   const providerMatched = new Set<string>();
+  const callsignSkip = new Set(['USA', 'UHD', 'WEST', 'EAST', 'COZI', 'CBSN', 'CSPAN', 'CNBC', 'CMT', 'CNN', 'CBS', 'CMA', 'CITY', 'CRIME', 'WORLD', 'CGTN', 'WWE', 'NBC', 'ABC', 'FOX', 'PBS', 'CW']);
 
   for (const ch of providerChannels) {
     if (providerMatched.has(ch.stream_id)) continue;
@@ -135,14 +149,13 @@ function buildMatchedXmltvIds(xmltvChannels: EpgChannel[], providerChannels: Pro
 
     // Strategy 11: Extract call signs from channel name
     {
-      const skip = new Set(['USA', 'UHD', 'WEST', 'EAST', 'COZI', 'CBSN', 'CSPAN', 'CNBC', 'CMT', 'CNN', 'CBS', 'CMA', 'CITY', 'CRIME', 'WORLD', 'CGTN', 'WWE', 'NBC', 'ABC', 'FOX', 'PBS', 'CW']);
       const parenMatches = ch.name.match(/\(([A-Z][A-Z0-9\-]{2,8})\)/g) || [];
       const parenSigns = parenMatches.map(s => s.slice(1, -1).replace(/-/g, ''));
       const textSigns = ch.name.match(/\b([KWCX][A-Z]{2,4}(?:-?DT\d?)?)\b/g) || [];
       const allSigns = [...parenSigns, ...textSigns.map(s => s.replace(/-/g, ''))];
 
       for (const sign of allSigns) {
-        if (skip.has(sign) || sign.length < 3) continue;
+        if (callsignSkip.has(sign) || sign.length < 3) continue;
         const code = sign.toLowerCase();
         const cm = codeMap.get(code)
           || codeMap.get(code + 'dt')
@@ -210,7 +223,7 @@ function buildMatchedXmltvIds(xmltvChannels: EpgChannel[], providerChannels: Pro
       }
     }
     if (fuzzyMatched > 0) {
-      console.log(`[epg-worker] Fuzzy fallback matched ${fuzzyMatched} additional channels`);
+      workerLog(`[epg-worker] Fuzzy fallback matched ${fuzzyMatched} additional channels`);
     }
   }
 
@@ -238,12 +251,16 @@ function streamParseXmltv(
     let skipped = 0;
 
     function extractAttr(tag: string, name: string): string | null {
-      const key = name + '="';
-      const i = tag.indexOf(key);
-      if (i === -1) return null;
-      const s = i + key.length;
-      const e = tag.indexOf('"', s);
-      return e === -1 ? null : tag.slice(s, e);
+      for (const q of ['"', "'"]) {
+        const key = name + '=' + q;
+        const i = tag.indexOf(key);
+        if (i === -1) continue;
+        const s = i + key.length;
+        const e = tag.indexOf(q, s);
+        if (e === -1) continue;
+        return tag.slice(s, e);
+      }
+      return null;
     }
 
     function extractChild(block: string, tagName: string): string {
@@ -351,6 +368,7 @@ function streamParseXmltv(
       // Prevent remainder from growing unbounded — if it's huge and has no complete elements,
       // keep only the last 64KB (enough for any single element)
       if (remainder.length > 1024 * 1024) {
+        workerLog(`[epg-worker] WARNING: Remainder buffer overflow (${remainder.length} bytes), truncating to 64KB — possible oversized element`);
         const keepFrom = remainder.length - 64 * 1024;
         remainder = remainder.slice(keepFrom);
       }
@@ -367,47 +385,55 @@ function streamParseXmltv(
 }
 
 // ---- Entry point ----
-const { filePath, providerChannels } = workerData as {
-  filePath: string;
-  providerChannels?: ProviderChannel[];
-};
+if (!parentPort) throw new Error('epg-parse-worker must be run as a worker thread');
 
-const fileSize = statSync(filePath).size;
-console.log(`[epg-worker] Stream-parsing ${Math.round(fileSize / 1024 / 1024)}MB file (${providerChannels?.length ?? 0} provider channels for filtering)...`);
-const t0 = Date.now();
+try {
+  const { filePath, providerChannels } = workerData as {
+    filePath: string;
+    providerChannels?: ProviderChannel[];
+  };
 
-let filterIds: Set<string> | null = null;
+  const fileSize = statSync(filePath).size;
+  workerLog(`[epg-worker] Stream-parsing ${Math.round(fileSize / 1024 / 1024)}MB file (${providerChannels?.length ?? 0} provider channels for filtering)...`);
+  const t0 = Date.now();
 
-if (providerChannels && providerChannels.length > 0) {
-  // Phase 1: Quick stream scan for <channel> elements only
-  console.log(`[epg-worker] Phase 1: scanning for channel elements...`);
-  const xmltvChannels: EpgChannel[] = [];
+  let filterIds: Set<string> | null = null;
 
-  await streamParseXmltv(filePath, null,
-    (ch) => xmltvChannels.push(ch),
-    () => {}, // skip all programmes in phase 1
+  if (providerChannels && providerChannels.length > 0) {
+    // Phase 1: Quick stream scan for <channel> elements only
+    workerLog(`[epg-worker] Phase 1: scanning for channel elements...`);
+    const xmltvChannels: EpgChannel[] = [];
+
+    await streamParseXmltv(filePath, null,
+      (ch) => xmltvChannels.push(ch),
+      () => {}, // skip all programmes in phase 1
+    );
+    workerLog(`[epg-worker] Found ${xmltvChannels.length} EPG channels`);
+
+    // Run matching
+    filterIds = buildMatchedXmltvIds(xmltvChannels, providerChannels);
+    workerLog(`[epg-worker] Matched ${filterIds.size}/${providerChannels.length} provider channels — will filter programmes`);
+  }
+
+  // Phase 2: Full parse with filter
+  const channels: EpgChannel[] = [];
+  const programs: EpgProgram[] = [];
+
+  const stats = await streamParseXmltv(filePath, filterIds,
+    (ch) => channels.push(ch),
+    (p) => programs.push(p),
   );
-  console.log(`[epg-worker] Found ${xmltvChannels.length} EPG channels`);
 
-  // Run matching
-  filterIds = buildMatchedXmltvIds(xmltvChannels, providerChannels);
-  console.log(`[epg-worker] Matched ${filterIds.size}/${providerChannels.length} provider channels — will filter programmes`);
+  if (stats.skipped > 0) {
+    workerLog(`[epg-worker] Skipped ${stats.skipped} programmes for non-matching channels`);
+  }
+
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  workerLog(`[epg-worker] Done: ${channels.length} channels, ${programs.length} programs in ${elapsed}s`);
+
+  parentPort.postMessage({ channels, programs });
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  workerLog(`[epg-worker] ERROR: Fatal error: ${msg}`);
+  parentPort.postMessage({ error: msg });
 }
-
-// Phase 2: Full parse with filter
-const channels: EpgChannel[] = [];
-const programs: EpgProgram[] = [];
-
-const stats = await streamParseXmltv(filePath, filterIds,
-  (ch) => channels.push(ch),
-  (p) => programs.push(p),
-);
-
-if (stats.skipped > 0) {
-  console.log(`[epg-worker] Skipped ${stats.skipped} programmes for non-matching channels`);
-}
-
-const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-console.log(`[epg-worker] Done: ${channels.length} channels, ${programs.length} programs in ${elapsed}s`);
-
-parentPort!.postMessage({ channels, programs });

--- a/packages/electron/src/epg-parse-worker.ts
+++ b/packages/electron/src/epg-parse-worker.ts
@@ -214,25 +214,6 @@ function buildMatchedXmltvIds(xmltvChannels: EpgChannel[], providerChannels: Pro
     }
   }
 
-  // Debug
-  const unmatched = providerChannels.filter(ch => !providerMatched.has(ch.stream_id));
-  if (unmatched.length > 0) {
-    console.log(`[epg-worker] Sample unmatched provider channels (first 15):`);
-    for (const ch of unmatched.slice(0, 15)) {
-      const norm = normalize(ch.name);
-      const slug = ch.epg_channel_id ? slugify(ch.epg_channel_id) : '';
-      const base = ch.epg_channel_id ? stripTld(ch.epg_channel_id) : '';
-      console.log(`  provider: name="${ch.name}" epg_id="${ch.epg_channel_id}" norm="${norm}" slug="${slug}" base="${base}"`);
-    }
-    console.log(`[epg-worker] Sample EPG channels (first 15):`);
-    for (const xch of xmltvChannels.slice(0, 15)) {
-      const code = extractCodes(xch.id).join(',');
-      const slug = slugify(xch.id);
-      const norms = xch.displayNames.map(dn => normalize(dn));
-      console.log(`  epg: id="${xch.id}" code="${code}" slug="${slug}" names=${JSON.stringify(xch.displayNames)} norms=${JSON.stringify(norms)}`);
-    }
-  }
-
   return matched;
 }
 

--- a/packages/electron/src/epg-parse-worker.ts
+++ b/packages/electron/src/epg-parse-worker.ts
@@ -1,0 +1,432 @@
+/**
+ * EPG Parse Worker Thread
+ * Stream-parses XMLTV from a file — constant memory usage, handles any file size.
+ * If provider channels are given, matches them first (quick channel scan) then
+ * only parses matching programmes on the second pass.
+ */
+import { parentPort, workerData } from 'worker_threads';
+import { createReadStream, statSync } from 'fs';
+
+interface EpgChannel { id: string; displayNames: string[]; }
+interface EpgProgram { channel_id: string; title: string; description: string; start: string; stop: string; }
+interface ProviderChannel { epg_channel_id: string; name: string; stream_id: string; }
+
+// ---- Matching helpers (same logic as epg-matcher.ts) ----
+
+function normalize(name: string): string {
+  let s = name;
+  s = s.replace(/^(USA?|UK|CA|AU|NZ|FR|DE|ES|IT|PT|NL|BE|AT|CH|IE|IN)\s*[:\-|]?\s*/i, '');
+  while (/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i.test(s)) {
+    s = s.replace(/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i, '');
+  }
+  s = s.toLowerCase();
+  s = s.replace(/&/g, 'and').replace(/\+/g, 'plus');
+  return s.replace(/[^a-z0-9]/g, '');
+}
+
+function normalizeLooser(name: string): string {
+  let s = normalize(name);
+  s = s.replace(/^the/, '');
+  s = s.replace(/(channel|network|television|tv)$/, '');
+  return s;
+}
+
+function extractCodes(epgId: string): string[] {
+  const matches = epgId.match(/\(([^)]+)\)/g);
+  if (!matches) return [];
+  return matches.map(m => m.slice(1, -1).toLowerCase());
+}
+
+function slugify(id: string): string {
+  return id.replace(/\.\w{2,3}$/, '').replace(/\([^)]*\)/, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function stripTld(id: string): string {
+  return id.replace(/\.\w{2,3}$/, '').toLowerCase();
+}
+
+function decodeEntities(s: string): string {
+  if (s.indexOf('&') === -1) return s;
+  return s
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, c) => String.fromCharCode(parseInt(c, 10)));
+}
+
+function parseDate(d: string): string | null {
+  const m = d.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\s*([+-]\d{4})?$/);
+  if (!m) return null;
+  const [, yr, mo, dy, hr, mn, sc, tz] = m;
+  return `${yr}-${mo}-${dy}T${hr}:${mn}:${sc}${tz ? tz.slice(0, 3) + ':' + tz.slice(3) : 'Z'}`;
+}
+
+// ---- Matching logic ----
+
+function buildMatchedXmltvIds(xmltvChannels: EpgChannel[], providerChannels: ProviderChannel[]): Set<string> {
+  const matched = new Set<string>();
+
+  const exactMap = new Map<string, string>();
+  const codeMap = new Map<string, string>();
+  const displayNameMap = new Map<string, string>();
+  const slugMap = new Map<string, string>();
+  const looseNameMap = new Map<string, string>();
+  const looseSlugMap = new Map<string, string>();
+
+  for (const xch of xmltvChannels) {
+    exactMap.set(xch.id, xch.id);
+    for (const code of extractCodes(xch.id)) {
+      codeMap.set(code, xch.id);
+      const dtMatch = code.match(/^(.+?)dt(\d?)$/);
+      if (dtMatch) {
+        const baseCall = dtMatch[1];
+        const dtNum = dtMatch[2];
+        if (!dtNum || !codeMap.has(baseCall)) {
+          codeMap.set(baseCall, xch.id);
+        }
+      }
+    }
+    for (const dn of xch.displayNames) {
+      const norm = normalize(dn);
+      if (norm) displayNameMap.set(norm, xch.id);
+      const loose = normalizeLooser(dn);
+      if (loose) looseNameMap.set(loose, xch.id);
+    }
+    const slug = slugify(xch.id);
+    if (slug) {
+      slugMap.set(slug, xch.id);
+      const looseSlug = slug.replace(/(channel|network|television|tv)$/, '');
+      if (looseSlug) looseSlugMap.set(looseSlug, xch.id);
+    }
+  }
+
+  const providerMatched = new Set<string>();
+
+  for (const ch of providerChannels) {
+    if (providerMatched.has(ch.stream_id)) continue;
+    const norm = normalize(ch.name);
+    const loose = normalizeLooser(ch.name);
+
+    if (ch.epg_channel_id) {
+      const ex = exactMap.get(ch.epg_channel_id);
+      if (ex) { matched.add(ex); providerMatched.add(ch.stream_id); continue; }
+      const base = stripTld(ch.epg_channel_id);
+      if (base) { const cm = codeMap.get(base); if (cm) { matched.add(cm); providerMatched.add(ch.stream_id); continue; } }
+    }
+    if (norm) { const dm = displayNameMap.get(norm); if (dm) { matched.add(dm); providerMatched.add(ch.stream_id); continue; } }
+    if (norm) { const cm2 = codeMap.get(norm); if (cm2) { matched.add(cm2); providerMatched.add(ch.stream_id); continue; } }
+    if (ch.epg_channel_id) {
+      const slug = slugify(ch.epg_channel_id);
+      if (slug) { const sm = slugMap.get(slug); if (sm) { matched.add(sm); providerMatched.add(ch.stream_id); continue; } }
+    }
+    if (ch.epg_channel_id) {
+      const base = stripTld(ch.epg_channel_id);
+      if (base) { const dm2 = displayNameMap.get(base); if (dm2) { matched.add(dm2); providerMatched.add(ch.stream_id); continue; } }
+    }
+    if (loose) { const lm = looseNameMap.get(loose); if (lm) { matched.add(lm); providerMatched.add(ch.stream_id); continue; } }
+    if (loose) { const lc = codeMap.get(loose); if (lc) { matched.add(lc); providerMatched.add(ch.stream_id); continue; } }
+    if (ch.epg_channel_id) {
+      const baseLo = normalizeLooser(stripTld(ch.epg_channel_id));
+      if (baseLo) {
+        const bl = looseNameMap.get(baseLo); if (bl) { matched.add(bl); providerMatched.add(ch.stream_id); continue; }
+        const bls = looseSlugMap.get(baseLo); if (bls) { matched.add(bls); providerMatched.add(ch.stream_id); continue; }
+      }
+    }
+    if (loose) { const ls = looseSlugMap.get(loose); if (ls) { matched.add(ls); providerMatched.add(ch.stream_id); continue; } }
+
+    // Strategy 11: Extract call signs from channel name
+    {
+      const skip = new Set(['USA', 'UHD', 'WEST', 'EAST', 'COZI', 'CBSN', 'CSPAN', 'CNBC', 'CMT', 'CNN', 'CBS', 'CMA', 'CITY', 'CRIME', 'WORLD', 'CGTN', 'WWE', 'NBC', 'ABC', 'FOX', 'PBS', 'CW']);
+      const parenMatches = ch.name.match(/\(([A-Z][A-Z0-9\-]{2,8})\)/g) || [];
+      const parenSigns = parenMatches.map(s => s.slice(1, -1).replace(/-/g, ''));
+      const textSigns = ch.name.match(/\b([KWCX][A-Z]{2,4}(?:-?DT\d?)?)\b/g) || [];
+      const allSigns = [...parenSigns, ...textSigns.map(s => s.replace(/-/g, ''))];
+
+      for (const sign of allSigns) {
+        if (skip.has(sign) || sign.length < 3) continue;
+        const code = sign.toLowerCase();
+        const cm = codeMap.get(code)
+          || codeMap.get(code + 'dt')
+          || (code.match(/dt\d?$/) ? codeMap.get(code.replace(/dt\d?$/, '')) : null);
+        if (cm) { matched.add(cm); providerMatched.add(ch.stream_id); break; }
+      }
+      if (providerMatched.has(ch.stream_id)) continue;
+    }
+  }
+
+  // Strategy 12: Lightweight fuzzy fallback — word overlap + substring matching
+  {
+    const wordIndex = new Map<string, Set<string>>();
+    for (const xch of xmltvChannels) {
+      for (const dn of xch.displayNames) {
+        const words = normalize(dn).match(/[a-z]{3,}/g) || [];
+        for (const w of words) {
+          if (!wordIndex.has(w)) wordIndex.set(w, new Set());
+          wordIndex.get(w)!.add(xch.id);
+        }
+      }
+    }
+
+    const epgNormById = new Map<string, string>();
+    for (const xch of xmltvChannels) {
+      if (xch.displayNames.length > 0) {
+        epgNormById.set(xch.id, normalize(xch.displayNames[0]));
+      }
+    }
+
+    let fuzzyMatched = 0;
+    for (const ch of providerChannels) {
+      if (providerMatched.has(ch.stream_id)) continue;
+      const norm = normalize(ch.name);
+      if (!norm || norm.length < 4) continue;
+      const words = norm.match(/[a-z]{3,}/g) || [];
+      if (words.length === 0) continue;
+
+      const candidates = new Map<string, number>();
+      for (const w of words) {
+        const ids = wordIndex.get(w);
+        if (ids) {
+          for (const id of ids) candidates.set(id, (candidates.get(id) || 0) + 1);
+        }
+      }
+
+      let bestId: string | null = null;
+      let bestScore = 0;
+      for (const [id, wordOverlap] of candidates) {
+        if (wordOverlap < Math.max(1, words.length * 0.4)) continue;
+        const epgNorm = epgNormById.get(id);
+        if (!epgNorm) continue;
+        const shorter = norm.length < epgNorm.length ? norm : epgNorm;
+        const longer = norm.length >= epgNorm.length ? norm : epgNorm;
+        if (longer.includes(shorter) || shorter.includes(longer)) {
+          const score = shorter.length / longer.length;
+          if (score > bestScore && score >= 0.6) { bestScore = score; bestId = id; }
+        }
+      }
+
+      if (bestId) {
+        matched.add(bestId);
+        providerMatched.add(ch.stream_id);
+        fuzzyMatched++;
+      }
+    }
+    if (fuzzyMatched > 0) {
+      console.log(`[epg-worker] Fuzzy fallback matched ${fuzzyMatched} additional channels`);
+    }
+  }
+
+  // Debug
+  const unmatched = providerChannels.filter(ch => !providerMatched.has(ch.stream_id));
+  if (unmatched.length > 0) {
+    console.log(`[epg-worker] Sample unmatched provider channels (first 15):`);
+    for (const ch of unmatched.slice(0, 15)) {
+      const norm = normalize(ch.name);
+      const slug = ch.epg_channel_id ? slugify(ch.epg_channel_id) : '';
+      const base = ch.epg_channel_id ? stripTld(ch.epg_channel_id) : '';
+      console.log(`  provider: name="${ch.name}" epg_id="${ch.epg_channel_id}" norm="${norm}" slug="${slug}" base="${base}"`);
+    }
+    console.log(`[epg-worker] Sample EPG channels (first 15):`);
+    for (const xch of xmltvChannels.slice(0, 15)) {
+      const code = extractCodes(xch.id).join(',');
+      const slug = slugify(xch.id);
+      const norms = xch.displayNames.map(dn => normalize(dn));
+      console.log(`  epg: id="${xch.id}" code="${code}" slug="${slug}" names=${JSON.stringify(xch.displayNames)} norms=${JSON.stringify(norms)}`);
+    }
+  }
+
+  return matched;
+}
+
+// ---- Stream parser ----
+
+/**
+ * Stream-parse an XMLTV file. Reads the file line by line, accumulates element blocks,
+ * and emits parsed channel/programme objects. Constant memory — handles any file size.
+ */
+function streamParseXmltv(
+  filePath: string,
+  filterChannelIds: Set<string> | null,
+  onChannel: (ch: EpgChannel) => void,
+  onProgram: (p: EpgProgram) => void,
+): Promise<{ channelCount: number; programCount: number; skipped: number }> {
+  return new Promise((resolve, reject) => {
+    const stream = createReadStream(filePath, { encoding: 'utf-8', highWaterMark: 256 * 1024 });
+
+    let remainder = '';
+    let channelCount = 0;
+    let programCount = 0;
+    let skipped = 0;
+
+    function extractAttr(tag: string, name: string): string | null {
+      const key = name + '="';
+      const i = tag.indexOf(key);
+      if (i === -1) return null;
+      const s = i + key.length;
+      const e = tag.indexOf('"', s);
+      return e === -1 ? null : tag.slice(s, e);
+    }
+
+    function extractChild(block: string, tagName: string): string {
+      const open = '<' + tagName;
+      const p = block.indexOf(open);
+      if (p === -1) return '';
+      const te = block.indexOf('>', p);
+      if (te === -1) return '';
+      const close = '</' + tagName + '>';
+      const cp = block.indexOf(close, te + 1);
+      if (cp === -1) return '';
+      return block.slice(te + 1, cp);
+    }
+
+    function processBlock(block: string) {
+      // Detect element type from opening tag
+      const trimmed = block.trimStart();
+
+      if (trimmed.startsWith('<channel ')) {
+        const tagEnd = block.indexOf('>');
+        if (tagEnd === -1) return;
+        const id = extractAttr(block.slice(0, tagEnd + 1), 'id');
+        if (!id) return;
+
+        const decodedId = decodeEntities(id);
+        const displayNames: string[] = [];
+        let pos = tagEnd + 1;
+        while (true) {
+          const ds = block.indexOf('<display-name', pos);
+          if (ds === -1) break;
+          const dte = block.indexOf('>', ds);
+          if (dte === -1) break;
+          const dcp = block.indexOf('</display-name>', dte + 1);
+          if (dcp === -1) break;
+          const nm = decodeEntities(block.slice(dte + 1, dcp)).trim();
+          if (nm) displayNames.push(nm);
+          pos = dcp + 15;
+        }
+
+        channelCount++;
+        onChannel({ id: decodedId, displayNames });
+      } else if (trimmed.startsWith('<programme ')) {
+        const tagEnd = block.indexOf('>');
+        if (tagEnd === -1) return;
+        const openTag = block.slice(0, tagEnd + 1);
+
+        const channelId = extractAttr(openTag, 'channel');
+        if (!channelId) return;
+
+        // Fast skip if channel not in filter
+        const decodedChannelId = decodeEntities(channelId);
+        if (filterChannelIds && !filterChannelIds.has(decodedChannelId)) {
+          skipped++;
+          return;
+        }
+
+        const startStr = extractAttr(openTag, 'start');
+        const stopStr = extractAttr(openTag, 'stop');
+        if (!startStr || !stopStr) return;
+
+        const start = parseDate(startStr);
+        const stop = parseDate(stopStr);
+        if (!start || !stop) return;
+
+        const title = decodeEntities(extractChild(block, 'title'));
+        if (!title) return;
+        const desc = decodeEntities(extractChild(block, 'desc'));
+
+        programCount++;
+        onProgram({ channel_id: decodedChannelId, title, description: desc, start, stop });
+      }
+    }
+
+    stream.on('data', (chunk) => {
+      remainder += chunk;
+
+      // Process complete elements: find </channel> and </programme> closing tags
+      let idx: number;
+      while (true) {
+        // Find the next closing tag
+        const chClose = remainder.indexOf('</channel>');
+        const prClose = remainder.indexOf('</programme>');
+
+        if (chClose === -1 && prClose === -1) break;
+
+        // Pick whichever comes first
+        let closeTag: string;
+        if (chClose === -1) { closeTag = '</programme>'; idx = prClose; }
+        else if (prClose === -1) { closeTag = '</channel>'; idx = chClose; }
+        else if (chClose < prClose) { closeTag = '</channel>'; idx = chClose; }
+        else { closeTag = '</programme>'; idx = prClose; }
+
+        const endPos = idx + closeTag.length;
+        const block = remainder.slice(0, endPos);
+        remainder = remainder.slice(endPos);
+
+        // Find the matching opening tag within this block
+        const openTag = closeTag === '</channel>' ? '<channel ' : '<programme ';
+        const openIdx = block.lastIndexOf(openTag);
+        if (openIdx !== -1) {
+          processBlock(block.slice(openIdx));
+        }
+      }
+
+      // Prevent remainder from growing unbounded — if it's huge and has no complete elements,
+      // keep only the last 64KB (enough for any single element)
+      if (remainder.length > 1024 * 1024) {
+        const keepFrom = remainder.length - 64 * 1024;
+        remainder = remainder.slice(keepFrom);
+      }
+    });
+
+    stream.on('end', () => {
+      resolve({ channelCount, programCount, skipped });
+    });
+
+    stream.on('error', (err) => {
+      reject(err);
+    });
+  });
+}
+
+// ---- Entry point ----
+const { filePath, providerChannels } = workerData as {
+  filePath: string;
+  providerChannels?: ProviderChannel[];
+};
+
+const fileSize = statSync(filePath).size;
+console.log(`[epg-worker] Stream-parsing ${Math.round(fileSize / 1024 / 1024)}MB file (${providerChannels?.length ?? 0} provider channels for filtering)...`);
+const t0 = Date.now();
+
+let filterIds: Set<string> | null = null;
+
+if (providerChannels && providerChannels.length > 0) {
+  // Phase 1: Quick stream scan for <channel> elements only
+  console.log(`[epg-worker] Phase 1: scanning for channel elements...`);
+  const xmltvChannels: EpgChannel[] = [];
+
+  await streamParseXmltv(filePath, null,
+    (ch) => xmltvChannels.push(ch),
+    () => {}, // skip all programmes in phase 1
+  );
+  console.log(`[epg-worker] Found ${xmltvChannels.length} EPG channels`);
+
+  // Run matching
+  filterIds = buildMatchedXmltvIds(xmltvChannels, providerChannels);
+  console.log(`[epg-worker] Matched ${filterIds.size}/${providerChannels.length} provider channels — will filter programmes`);
+}
+
+// Phase 2: Full parse with filter
+const channels: EpgChannel[] = [];
+const programs: EpgProgram[] = [];
+
+const stats = await streamParseXmltv(filePath, filterIds,
+  (ch) => channels.push(ch),
+  (p) => programs.push(p),
+);
+
+if (stats.skipped > 0) {
+  console.log(`[epg-worker] Skipped ${stats.skipped} programmes for non-matching channels`);
+}
+
+const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+console.log(`[epg-worker] Done: ${channels.length} channels, ${programs.length} programs in ${elapsed}s`);
+
+parentPort!.postMessage({ channels, programs });

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -1204,6 +1204,150 @@ ipcMain.handle('fetch-binary', async (_event, url: string) => {
   }
 });
 
+// =========================================================================
+// EPG: Fetch, decompress, and parse XMLTV in a worker thread
+// Main process stays unblocked; only structured results cross IPC
+// =========================================================================
+import { Worker as WorkerThread } from 'worker_threads';
+
+interface ProviderChannelInfo {
+  epg_channel_id: string;
+  name: string;
+  stream_id: string;
+}
+
+function parseEpgInWorkerThread(filePath: string, providerChannels?: ProviderChannelInfo[]): Promise<{ channels: { id: string; displayNames: string[] }[]; programs: { channel_id: string; title: string; description: string; start: string; stop: string }[] }> {
+  return new Promise((resolve, reject) => {
+    const workerPath = path.join(__dirname, 'epg-parse-worker.js');
+    const worker = new WorkerThread(workerPath, {
+      workerData: { filePath, providerChannels },
+      resourceLimits: { maxOldGenerationSizeMb: 8192 },
+    });
+    worker.on('message', (result) => {
+      resolve(result);
+      worker.terminate();
+    });
+    worker.on('error', (err) => {
+      reject(err);
+      worker.terminate();
+    });
+    worker.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`EPG worker exited with code ${code}`));
+    });
+  });
+}
+
+// Stream download to temp file (avoids ArrayBuffer size limits for large EPG files)
+async function downloadToTempFile(url: string): Promise<string> {
+  const { createWriteStream } = await import('fs');
+  const { randomUUID } = await import('crypto');
+  const { tmpdir } = await import('os');
+
+  const tmpPath = path.join(tmpdir(), `epg-${randomUUID()}.tmp`);
+  const response = await electronNet.fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+  if (!response.body) {
+    throw new Error('No response body');
+  }
+
+  // Stream response body to file
+  const fileStream = createWriteStream(tmpPath);
+  // Convert Web ReadableStream to Node stream
+  const reader = response.body.getReader();
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      fileStream.write(Buffer.from(value));
+      totalBytes += value.byteLength;
+    }
+    fileStream.end();
+    await new Promise<void>((resolve, reject) => {
+      fileStream.on('finish', resolve);
+      fileStream.on('error', reject);
+    });
+  } catch (err) {
+    fileStream.destroy();
+    throw err;
+  }
+
+  console.log(`[epg] Downloaded ${Math.round(totalBytes / 1024 / 1024)}MB to temp file`);
+  return tmpPath;
+}
+
+// Read file, optionally decompress via streaming to another temp file, return path to raw XML
+// Streaming avoids holding 3GB+ decompressed data in a single Buffer
+async function decompressToFile(filePath: string, isGz: boolean): Promise<{ xmlPath: string; sizeMB: number }> {
+  const { createReadStream, createWriteStream, statSync, unlinkSync } = await import('fs');
+  const { createGunzip } = await import('zlib');
+  const { pipeline } = await import('stream/promises');
+  const { randomUUID } = await import('crypto');
+  const { tmpdir } = await import('os');
+
+  // Check magic bytes
+  if (!isGz) {
+    const { readSync, openSync, closeSync } = await import('fs');
+    const fd = openSync(filePath, 'r');
+    const header = Buffer.alloc(2);
+    readSync(fd, header, 0, 2, 0);
+    closeSync(fd);
+    isGz = header[0] === 0x1f && header[1] === 0x8b;
+  }
+
+  if (!isGz) {
+    const size = statSync(filePath).size;
+    return { xmlPath: filePath, sizeMB: Math.round(size / 1024 / 1024) };
+  }
+
+  const xmlPath = path.join(tmpdir(), `epg-xml-${randomUUID()}.tmp`);
+  const compressedSize = statSync(filePath).size;
+  console.log(`[epg] Streaming decompression of ${Math.round(compressedSize / 1024 / 1024)}MB...`);
+
+  await pipeline(
+    createReadStream(filePath),
+    createGunzip(),
+    createWriteStream(xmlPath),
+  );
+
+  // Clean up compressed file
+  try { unlinkSync(filePath); } catch {}
+
+  const decompressedSize = statSync(xmlPath).size;
+  console.log(`[epg] Decompressed to ${Math.round(decompressedSize / 1024 / 1024)}MB on disk`);
+  return { xmlPath, sizeMB: Math.round(decompressedSize / 1024 / 1024) };
+}
+
+// Fetch, decompress, and parse EPG — parsing runs in a worker thread
+ipcMain.handle('fetch-and-parse-epg', async (_event, url: string, providerChannels?: ProviderChannelInfo[]) => {
+  const settings = storage.getSettings();
+  if (!isAllowedBinaryUrl(url, settings.allowLanSources ?? false)) {
+    return { success: false, error: 'Blocked: Local network access is disabled. Enable "Allow LAN sources" in Settings > System > Security if you trust this source.' };
+  }
+  try {
+    console.log(`[epg] Fetching ${url}...`);
+    const tmpPath = await downloadToTempFile(url);
+
+    const isGz = url.endsWith('.gz');
+    const { xmlPath, sizeMB } = await decompressToFile(tmpPath, isGz);
+
+    // Worker stream-parses from the file — no memory limits
+    console.log(`[epg] Parsing ${sizeMB}MB in worker thread...`);
+    const t0 = Date.now();
+    const result = await parseEpgInWorkerThread(xmlPath, providerChannels);
+    // Clean up temp file
+    try { (await import('fs')).unlinkSync(xmlPath); } catch {}
+    console.log(`[epg] Parsed ${result.channels.length} channels, ${result.programs.length} programs in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+    return { success: true, data: result };
+  } catch (error) {
+    console.error('[epg] Parse failed:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Fetch/parse failed' };
+  }
+});
+
 // App lifecycle
 app.whenReady().then(async () => {
   // Initialize debug logging from saved settings

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -1126,7 +1126,9 @@ function isAllowedBinaryUrl(url: string, allowLan: boolean): boolean {
 const BLOCKED_URL_PATTERNS = [
   /^https?:\/\/localhost(?::\d+)?(?:\/|$)/i,
   /^https?:\/\/127\.\d+\.\d+\.\d+/,
+  /^https?:\/\/0\.0\.0\.0/,                     // Alternative localhost
   /^https?:\/\/\[?::1\]?/,                      // IPv6 localhost
+  /^https?:\/\/\[?::ffff:127\./,                // IPv4-mapped IPv6 localhost
   /^https?:\/\/10\.\d+\.\d+\.\d+/,              // Private Class A
   /^https?:\/\/172\.(1[6-9]|2\d|3[01])\./,      // Private Class B
   /^https?:\/\/192\.168\./,                     // Private Class C
@@ -1223,19 +1225,46 @@ function parseEpgInWorkerThread(filePath: string, providerChannels?: ProviderCha
       workerData: { filePath, providerChannels },
       resourceLimits: { maxOldGenerationSizeMb: 8192 },
     });
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      worker.terminate();
+      reject(new Error('EPG parse timed out after 8 minutes'));
+    }, 8 * 60 * 1000);
     worker.on('message', (result) => {
-      resolve(result);
+      if (result.type === 'log') {
+        debugLog(result.message, 'epg');
+        return;
+      }
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (result.error) {
+        reject(new Error(`EPG worker error: ${result.error}`));
+      } else {
+        resolve(result);
+      }
       worker.terminate();
     });
     worker.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
       reject(err);
       worker.terminate();
     });
     worker.on('exit', (code) => {
-      if (code !== 0) reject(new Error(`EPG worker exited with code ${code}`));
+      if (!settled && code !== 0) {
+        settled = true;
+        reject(new Error(`EPG worker exited with code ${code}`));
+      }
     });
   });
 }
+
+const MAX_DOWNLOAD_BYTES = 500 * 1024 * 1024;   // 500MB compressed
+const MAX_DECOMPRESS_BYTES = 4 * 1024 * 1024 * 1024; // 4GB decompressed
 
 // Stream download to temp file (avoids ArrayBuffer size limits for large EPG files)
 async function downloadToTempFile(url: string): Promise<string> {
@@ -1261,8 +1290,13 @@ async function downloadToTempFile(url: string): Promise<string> {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      fileStream.write(Buffer.from(value));
       totalBytes += value.byteLength;
+      if (totalBytes > MAX_DOWNLOAD_BYTES) {
+        fileStream.destroy();
+        try { (await import('fs')).unlinkSync(tmpPath); } catch {}
+        throw new Error(`EPG download exceeds ${MAX_DOWNLOAD_BYTES / 1024 / 1024}MB limit`);
+      }
+      fileStream.write(Buffer.from(value));
     }
     fileStream.end();
     await new Promise<void>((resolve, reject) => {
@@ -1271,6 +1305,7 @@ async function downloadToTempFile(url: string): Promise<string> {
     });
   } catch (err) {
     fileStream.destroy();
+    try { (await import('fs')).unlinkSync(tmpPath); } catch {}
     throw err;
   }
 
@@ -1306,14 +1341,30 @@ async function decompressToFile(filePath: string, isGz: boolean): Promise<{ xmlP
   const compressedSize = statSync(filePath).size;
   console.log(`[epg] Streaming decompression of ${Math.round(compressedSize / 1024 / 1024)}MB...`);
 
+  const { Transform } = await import('stream');
+  let decompressedBytes = 0;
+  const sizeGuard = new Transform({
+    transform(chunk, _encoding, callback) {
+      decompressedBytes += chunk.length;
+      if (decompressedBytes > MAX_DECOMPRESS_BYTES) {
+        callback(new Error(`EPG decompression exceeds ${MAX_DECOMPRESS_BYTES / 1024 / 1024 / 1024}GB limit`));
+      } else {
+        callback(null, chunk);
+      }
+    },
+  });
+
   await pipeline(
     createReadStream(filePath),
     createGunzip(),
+    sizeGuard,
     createWriteStream(xmlPath),
   );
 
   // Clean up compressed file
-  try { unlinkSync(filePath); } catch {}
+  try { unlinkSync(filePath); } catch (e) {
+    console.warn(`[epg] Failed to clean up compressed temp file ${filePath}:`, e);
+  }
 
   const decompressedSize = statSync(xmlPath).size;
   console.log(`[epg] Decompressed to ${Math.round(decompressedSize / 1024 / 1024)}MB on disk`);
@@ -1326,25 +1377,31 @@ ipcMain.handle('fetch-and-parse-epg', async (_event, url: string, providerChanne
   if (!isAllowedBinaryUrl(url, settings.allowLanSources ?? false)) {
     return { success: false, error: 'Blocked: Local network access is disabled. Enable "Allow LAN sources" in Settings > System > Security if you trust this source.' };
   }
+  const tempFiles: string[] = [];
   try {
     console.log(`[epg] Fetching ${url}...`);
     const tmpPath = await downloadToTempFile(url);
+    tempFiles.push(tmpPath);
 
     const isGz = url.endsWith('.gz');
     const { xmlPath, sizeMB } = await decompressToFile(tmpPath, isGz);
+    if (xmlPath !== tmpPath) tempFiles.push(xmlPath);
 
     // Worker stream-parses from the file — no memory limits
     console.log(`[epg] Parsing ${sizeMB}MB in worker thread...`);
     const t0 = Date.now();
     const result = await parseEpgInWorkerThread(xmlPath, providerChannels);
-    // Clean up temp file
-    try { (await import('fs')).unlinkSync(xmlPath); } catch {}
     console.log(`[epg] Parsed ${result.channels.length} channels, ${result.programs.length} programs in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
 
     return { success: true, data: result };
   } catch (error) {
     console.error('[epg] Parse failed:', error);
     return { success: false, error: error instanceof Error ? error.message : 'Fetch/parse failed' };
+  } finally {
+    const { unlinkSync } = await import('fs');
+    for (const f of tempFiles) {
+      try { unlinkSync(f); } catch {}
+    }
   }
 });
 

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -87,7 +87,6 @@ export interface FetchProxyResponse {
 export interface FetchProxyApi {
   fetch: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => Promise<StorageResult<FetchProxyResponse>>;
   fetchBinary: (url: string) => Promise<StorageResult<string>>; // Returns base64-encoded data
-  fetchAndDecompress: (url: string) => Promise<StorageResult<string>>; // Fetches + gunzips in main process, returns XML text
   fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) => Promise<StorageResult<{ channels: { id: string; displayNames: string[] }[]; programs: { channel_id: string; title: string; description: string; start: string; stop: string }[] }>>;
 }
 
@@ -168,8 +167,6 @@ contextBridge.exposeInMainWorld('fetchProxy', {
     ipcRenderer.invoke('fetch-proxy', url, options),
   fetchBinary: (url: string) =>
     ipcRenderer.invoke('fetch-binary', url),
-  fetchAndDecompress: (url: string) =>
-    ipcRenderer.invoke('fetch-and-decompress', url),
   fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) =>
     ipcRenderer.invoke('fetch-and-parse-epg', url, providerChannels),
 } satisfies FetchProxyApi);

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -87,6 +87,8 @@ export interface FetchProxyResponse {
 export interface FetchProxyApi {
   fetch: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => Promise<StorageResult<FetchProxyResponse>>;
   fetchBinary: (url: string) => Promise<StorageResult<string>>; // Returns base64-encoded data
+  fetchAndDecompress: (url: string) => Promise<StorageResult<string>>; // Fetches + gunzips in main process, returns XML text
+  fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) => Promise<StorageResult<{ channels: { id: string; displayNames: string[] }[]; programs: { channel_id: string; title: string; description: string; start: string; stop: string }[] }>>;
 }
 
 export interface DebugApi {
@@ -166,6 +168,10 @@ contextBridge.exposeInMainWorld('fetchProxy', {
     ipcRenderer.invoke('fetch-proxy', url, options),
   fetchBinary: (url: string) =>
     ipcRenderer.invoke('fetch-binary', url),
+  fetchAndDecompress: (url: string) =>
+    ipcRenderer.invoke('fetch-and-decompress', url),
+  fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) =>
+    ipcRenderer.invoke('fetch-and-parse-epg', url, providerChannels),
 } satisfies FetchProxyApi);
 
 // Expose platform info for conditional UI (e.g., resize grip on Windows only)

--- a/packages/local-adapter/src/index.ts
+++ b/packages/local-adapter/src/index.ts
@@ -3,8 +3,8 @@ export { parseM3U, fetchAndParseM3U } from './m3u-parser';
 export type { M3UParseResult } from './m3u-parser';
 
 // XMLTV Parser (shared by Xtream and M3U)
-export { parseXmltv } from './xmltv-parser';
-export type { XmltvProgram } from './xmltv-parser';
+export { parseXmltv, parseXmltvFull } from './xmltv-parser';
+export type { XmltvProgram, XmltvChannel, XmltvParseResult } from './xmltv-parser';
 
 // Xtream Client
 export { XtreamClient } from './xtream-client';

--- a/packages/local-adapter/src/xmltv-parser.ts
+++ b/packages/local-adapter/src/xmltv-parser.ts
@@ -48,13 +48,16 @@ function parseXmltvDate(dateStr: string): Date | null {
  * e.g. extractAttr('<programme start="2025" channel="abc">', 'channel') → 'abc'
  */
 function extractAttr(tag: string, name: string): string | null {
-  const key = name + '="';
-  const i = tag.indexOf(key);
-  if (i === -1) return null;
-  const start = i + key.length;
-  const end = tag.indexOf('"', start);
-  if (end === -1) return null;
-  return tag.slice(start, end);
+  for (const q of ['"', "'"]) {
+    const key = name + '=' + q;
+    const i = tag.indexOf(key);
+    if (i === -1) continue;
+    const start = i + key.length;
+    const end = tag.indexOf(q, start);
+    if (end === -1) continue;
+    return tag.slice(start, end);
+  }
+  return null;
 }
 
 /**
@@ -82,7 +85,8 @@ function extractChildText(xml: string, from: number, to: number, tagName: string
 
 /**
  * Parse XMLTV format returning both channel metadata and programs.
- * Uses indexOf-based scanning instead of regex to handle files of any size.
+ * Uses indexOf-based scanning instead of regex — V8's regex engine silently
+ * returns 0 matches on strings exceeding ~500MB with no error.
  */
 export function parseXmltvFull(xml: string): XmltvParseResult {
   const channels: XmltvChannel[] = [];
@@ -92,7 +96,9 @@ export function parseXmltvFull(xml: string): XmltvParseResult {
   const len = xml.length;
 
   // Once indexOf('<channel ', pos) returns -1, stop searching for channels —
-  // avoids rescanning the entire remaining string on every iteration
+  // avoids rescanning the entire remaining string on every iteration.
+  // NOTE: assumes channels appear before programmes (XMLTV convention, not spec requirement).
+  // Files with interleaved channels/programmes would silently miss late channels.
   let channelsDone = false;
 
   while (pos < len) {
@@ -196,5 +202,6 @@ function decodeXmlEntities(str: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)));
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, code) => String.fromCharCode(parseInt(code, 16)));
 }

--- a/packages/local-adapter/src/xmltv-parser.ts
+++ b/packages/local-adapter/src/xmltv-parser.ts
@@ -13,53 +13,22 @@ export interface XmltvProgram {
   stop: Date;
 }
 
+export interface XmltvChannel {
+  id: string;
+  displayNames: string[];
+}
+
+export interface XmltvParseResult {
+  channels: XmltvChannel[];
+  programs: XmltvProgram[];
+}
+
 /**
- * Parse XMLTV format EPG data
+ * Parse XMLTV format EPG data using indexOf-based scanning.
+ * Avoids regex on the full string which fails silently on very large files (500MB+).
  */
 export function parseXmltv(xml: string): XmltvProgram[] {
-  const programs: XmltvProgram[] = [];
-
-  // More flexible regex - extracts attributes individually since order varies
-  // Matches: <programme ...attributes... >content</programme>
-  const programPattern = /<programme\s+([^>]+)>([\s\S]*?)<\/programme>/gi;
-  const startAttr = /start="([^"]+)"/;
-  const stopAttr = /stop="([^"]+)"/;
-  const channelAttr = /channel="([^"]+)"/;
-  const titlePattern = /<title[^>]*>([^<]*)<\/title>/i;
-  const descPattern = /<desc[^>]*>([^<]*)<\/desc>/i;
-
-  let match;
-  while ((match = programPattern.exec(xml)) !== null) {
-    const [, attrs, content] = match;
-
-    const startMatch = attrs.match(startAttr);
-    const stopMatch = attrs.match(stopAttr);
-    const channelMatch = attrs.match(channelAttr);
-
-    if (!startMatch || !stopMatch || !channelMatch) continue;
-
-    const titleMatch = content.match(titlePattern);
-    const descMatch = content.match(descPattern);
-
-    const title = titleMatch ? decodeXmlEntities(titleMatch[1]) : '';
-    const desc = descMatch ? decodeXmlEntities(descMatch[1]) : '';
-
-    // Parse XMLTV date format: YYYYMMDDHHmmss +0000
-    const start = parseXmltvDate(startMatch[1]);
-    const stop = parseXmltvDate(stopMatch[1]);
-
-    if (start && stop && title) {
-      programs.push({
-        channel_id: channelMatch[1],
-        title,
-        description: desc,
-        start,
-        stop,
-      });
-    }
-  }
-
-  return programs;
+  return parseXmltvFull(xml).programs;
 }
 
 /**
@@ -72,6 +41,149 @@ function parseXmltvDate(dateStr: string): Date | null {
   const [, year, month, day, hour, min, sec, tz] = match;
   const isoStr = `${year}-${month}-${day}T${hour}:${min}:${sec}${tz ? tz.slice(0, 3) + ':' + tz.slice(3) : 'Z'}`;
   return new Date(isoStr);
+}
+
+/**
+ * Extract an XML attribute value from an opening tag string.
+ * e.g. extractAttr('<programme start="2025" channel="abc">', 'channel') → 'abc'
+ */
+function extractAttr(tag: string, name: string): string | null {
+  const key = name + '="';
+  const i = tag.indexOf(key);
+  if (i === -1) return null;
+  const start = i + key.length;
+  const end = tag.indexOf('"', start);
+  if (end === -1) return null;
+  return tag.slice(start, end);
+}
+
+/**
+ * Extract the text content of the first occurrence of a child element.
+ * Searches within `xml` between `from` and `to` indices.
+ * e.g. extractChildText(xml, 0, 500, 'title') → 'Movie Name'
+ */
+function extractChildText(xml: string, from: number, to: number, tagName: string): string {
+  // Find opening tag (may have attributes like lang="en")
+  const openSearch = '<' + tagName;
+  let pos = xml.indexOf(openSearch, from);
+  if (pos === -1 || pos >= to) return '';
+
+  // Find end of opening tag
+  const tagEnd = xml.indexOf('>', pos);
+  if (tagEnd === -1 || tagEnd >= to) return '';
+
+  // Find closing tag
+  const closeTag = '</' + tagName + '>';
+  const closePos = xml.indexOf(closeTag, tagEnd + 1);
+  if (closePos === -1 || closePos >= to) return '';
+
+  return xml.slice(tagEnd + 1, closePos);
+}
+
+/**
+ * Parse XMLTV format returning both channel metadata and programs.
+ * Uses indexOf-based scanning instead of regex to handle files of any size.
+ */
+export function parseXmltvFull(xml: string): XmltvParseResult {
+  const channels: XmltvChannel[] = [];
+  const programs: XmltvProgram[] = [];
+
+  let pos = 0;
+  const len = xml.length;
+
+  // Once indexOf('<channel ', pos) returns -1, stop searching for channels —
+  // avoids rescanning the entire remaining string on every iteration
+  let channelsDone = false;
+
+  while (pos < len) {
+    const nextChannel = channelsDone ? -1 : xml.indexOf('<channel ', pos);
+    const nextProgramme = xml.indexOf('<programme ', pos);
+    if (nextChannel === -1) channelsDone = true;
+
+    const chPos = nextChannel === -1 ? Infinity : nextChannel;
+    const prPos = nextProgramme === -1 ? Infinity : nextProgramme;
+
+    if (chPos === Infinity && prPos === Infinity) break;
+
+    if (chPos < prPos) {
+      // Parse <channel> element
+      const tagEnd = xml.indexOf('>', chPos);
+      if (tagEnd === -1) break;
+
+      // Check for self-closing
+      const isSelfClosing = xml[tagEnd - 1] === '/';
+      const openTag = xml.slice(chPos, tagEnd + 1);
+      const id = extractAttr(openTag, 'id');
+
+      if (isSelfClosing) {
+        if (id) channels.push({ id, displayNames: [] });
+        pos = tagEnd + 1;
+        continue;
+      }
+
+      // Find </channel>
+      const closeTag = '</channel>';
+      const closePos = xml.indexOf(closeTag, tagEnd + 1);
+      if (closePos === -1) { pos = tagEnd + 1; continue; }
+
+      if (id) {
+        // Extract all <display-name> children
+        const displayNames: string[] = [];
+        let dnPos = tagEnd + 1;
+        while (dnPos < closePos) {
+          const dnStart = xml.indexOf('<display-name', dnPos);
+          if (dnStart === -1 || dnStart >= closePos) break;
+
+          const dnTagEnd = xml.indexOf('>', dnStart);
+          if (dnTagEnd === -1 || dnTagEnd >= closePos) break;
+
+          const dnCloseTag = '</display-name>';
+          const dnClosePos = xml.indexOf(dnCloseTag, dnTagEnd + 1);
+          if (dnClosePos === -1 || dnClosePos >= closePos) break;
+
+          const name = decodeXmlEntities(xml.slice(dnTagEnd + 1, dnClosePos)).trim();
+          if (name) displayNames.push(name);
+          dnPos = dnClosePos + dnCloseTag.length;
+        }
+
+        channels.push({ id, displayNames });
+      }
+
+      pos = closePos + closeTag.length;
+    } else {
+      // Parse <programme> element
+      const tagEnd = xml.indexOf('>', prPos);
+      if (tagEnd === -1) break;
+
+      const openTag = xml.slice(prPos, tagEnd + 1);
+
+      // Find </programme>
+      const closeTag = '</programme>';
+      const closePos = xml.indexOf(closeTag, tagEnd + 1);
+      if (closePos === -1) { pos = tagEnd + 1; continue; }
+
+      const startStr = extractAttr(openTag, 'start');
+      const stopStr = extractAttr(openTag, 'stop');
+      const channelId = extractAttr(openTag, 'channel');
+
+      if (startStr && stopStr && channelId) {
+        const start = parseXmltvDate(startStr);
+        const stop = parseXmltvDate(stopStr);
+
+        if (start && stop) {
+          const title = decodeXmlEntities(extractChildText(xml, tagEnd + 1, closePos, 'title'));
+          if (title) {
+            const desc = decodeXmlEntities(extractChildText(xml, tagEnd + 1, closePos, 'desc'));
+            programs.push({ channel_id: channelId, title, description: desc, start, stop });
+          }
+        }
+      }
+
+      pos = closePos + closeTag.length;
+    }
+  }
+
+  return { channels, programs };
 }
 
 /**

--- a/packages/local-adapter/src/xtream-client.ts
+++ b/packages/local-adapter/src/xtream-client.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Channel, Category, Movie, Series, Season } from '@sbtltv/core';
-import { parseXmltv, type XmltvProgram } from './xmltv-parser';
+import { parseXmltv, parseXmltvFull, type XmltvProgram, type XmltvParseResult } from './xmltv-parser';
 
 export interface XtreamConfig {
   baseUrl: string;
@@ -312,6 +312,28 @@ export class XtreamClient {
 
     // Parse XMLTV using shared parser
     return parseXmltv(xmlText);
+  }
+
+  // Fetch full XMLTV EPG data with channel metadata
+  async getXmltvEpgFull(): Promise<XmltvParseResult> {
+    const url = this.getEpgUrl();
+
+    let xmlText: string;
+    if (typeof window !== 'undefined' && window.fetchProxy) {
+      const result = await window.fetchProxy.fetch(url);
+      if (!result.success || !result.data) {
+        throw new Error(result.error || 'Failed to fetch XMLTV');
+      }
+      xmlText = result.data.text;
+    } else {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch XMLTV: ${response.status}`);
+      }
+      xmlText = await response.text();
+    }
+
+    return parseXmltvFull(xmlText);
   }
 
   // ===========================================================================

--- a/packages/ui/src/db/index.ts
+++ b/packages/ui/src/db/index.ts
@@ -66,7 +66,7 @@ export interface UserPrefs {
 
 // EPG program entry
 export interface StoredProgram {
-  id: string; // `${stream_id}_${start}` compound key
+  id: string; // `${source_id}-${stream_id}-${start_ms}` compound key
   stream_id: string;
   title: string;
   description: string;
@@ -97,6 +97,12 @@ export interface StoredWatchlistItem {
   added: Date;
 }
 
+export type MatchStrategy =
+  | 'exact_id' | 'code_match' | 'display_name' | 'name_code'
+  | 'slug_match' | 'base_display' | 'loose_name' | 'loose_code'
+  | 'base_loose' | 'base_looseslug' | 'loose_looseslug'
+  | 'callsign' | 'fuzzy' | 'manual';
+
 // EPG channel mapping (external EPG → provider channels)
 export interface EpgMapping {
   id: string;                  // `${source_id}::${epg_source}::${epg_channel_id}`
@@ -106,7 +112,7 @@ export interface EpgMapping {
   epg_source: string;          // EPG URL this mapping applies to
   stream_id: string;           // Channel's stream_id for fast lookup
   confidence: 'exact' | 'high' | 'medium' | 'manual';
-  strategy: string;            // Which strategy produced this match
+  strategy: MatchStrategy;
 }
 
 // Watch progress (position tracking, Trakt-compatible)

--- a/packages/ui/src/db/index.ts
+++ b/packages/ui/src/db/index.ts
@@ -97,6 +97,18 @@ export interface StoredWatchlistItem {
   added: Date;
 }
 
+// EPG channel mapping (external EPG → provider channels)
+export interface EpgMapping {
+  id: string;                  // `${source_id}::${epg_source}::${epg_channel_id}`
+  source_id: string;
+  epg_channel_id: string;      // Provider's epg_channel_id
+  xmltv_channel_id: string;    // Matched XMLTV channel ID
+  epg_source: string;          // EPG URL this mapping applies to
+  stream_id: string;           // Channel's stream_id for fast lookup
+  confidence: 'exact' | 'high' | 'medium' | 'manual';
+  strategy: string;            // Which strategy produced this match
+}
+
 // Watch progress (position tracking, Trakt-compatible)
 export interface StoredWatchProgress {
   id: string;              // `${type}_${stream_id}` or `episode_${series_tmdb_id}_S${season}_E${episode}`
@@ -128,6 +140,7 @@ class SbtltvDatabase extends Dexie {
   favorites!: Table<StoredFavorite, string>;
   watchlist!: Table<StoredWatchlistItem, string>;
   watchProgress!: Table<StoredWatchProgress, string>;
+  epgMappings!: Table<EpgMapping, string>;
 
   constructor() {
     super('sbtltv');
@@ -265,6 +278,11 @@ class SbtltvDatabase extends Dexie {
     this.version(11).stores({
       watchProgress: 'id, type, tmdb_id, stream_id, series_tmdb_id, updated_at, [type+completed]',
     });
+
+    // Add EPG mapping table for external EPG channel matching
+    this.version(12).stores({
+      epgMappings: 'id, source_id, stream_id, [source_id+epg_source]',
+    });
   }
 }
 
@@ -272,11 +290,12 @@ export const db = new SbtltvDatabase();
 
 // Helper to clear all data for a source (before re-sync or on delete)
 export async function clearSourceData(sourceId: string): Promise<void> {
-  await db.transaction('rw', [db.channels, db.categories, db.sourcesMeta, db.programs], async () => {
+  await db.transaction('rw', [db.channels, db.categories, db.sourcesMeta, db.programs, db.epgMappings], async () => {
     await db.channels.where('source_id').equals(sourceId).delete();
     await db.categories.where('source_id').equals(sourceId).delete();
     await db.sourcesMeta.where('source_id').equals(sourceId).delete();
     await db.programs.where('source_id').equals(sourceId).delete();
+    await db.epgMappings.where('source_id').equals(sourceId).delete();
   });
 }
 
@@ -308,7 +327,7 @@ export async function purgeOrphanedData(validSourceIds: string[]): Promise<void>
   let vodOrphans = 0;
 
   await db.transaction('rw', [
-    db.channels, db.categories, db.sourcesMeta, db.programs,
+    db.channels, db.categories, db.sourcesMeta, db.programs, db.epgMappings,
     db.vodMovies, db.vodSeries, db.vodEpisodes, db.vodCategories,
   ], async () => {
     // Find orphaned source_ids in categories
@@ -324,6 +343,7 @@ export async function purgeOrphanedData(validSourceIds: string[]): Promise<void>
       await db.categories.where('source_id').equals(orphanId).delete();
       await db.sourcesMeta.where('source_id').equals(orphanId).delete();
       await db.programs.where('source_id').equals(orphanId).delete();
+      await db.epgMappings.where('source_id').equals(orphanId).delete();
     }
 
     // VOD side
@@ -361,6 +381,7 @@ export async function clearAllCachedData(): Promise<void> {
     db.vodSeries,
     db.vodEpisodes,
     db.vodCategories,
+    db.epgMappings,
   ], async () => {
     await db.channels.clear();
     await db.categories.clear();
@@ -370,6 +391,7 @@ export async function clearAllCachedData(): Promise<void> {
     await db.vodSeries.clear();
     await db.vodEpisodes.clear();
     await db.vodCategories.clear();
+    await db.epgMappings.clear();
   });
 }
 

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -1,6 +1,7 @@
 import { type Table } from 'dexie';
-import { db, clearSourceData, clearVodData, type SourceMeta, type StoredProgram, type StoredMovie, type StoredSeries, type StoredEpisode, type VodCategory } from './index';
-import { fetchAndParseM3U, XtreamClient, type XmltvProgram } from '@sbtltv/local-adapter';
+import { db, clearSourceData, clearVodData, type SourceMeta, type StoredProgram, type StoredMovie, type StoredSeries, type StoredEpisode, type VodCategory, type EpgMapping } from './index';
+import { fetchAndParseM3U, XtreamClient, type XmltvProgram, type XmltvChannel } from '@sbtltv/local-adapter';
+import { matchChannelsToEpg } from '../services/epg-matcher';
 import type { Source, Channel, Category, Movie, Series } from '@sbtltv/core';
 import { getEnrichedMovieExports, getEnrichedTvExports, findBestMatch, extractMatchParams } from '../services/tmdb-exports';
 import { useUIStore } from '../stores/uiStore';
@@ -70,26 +71,26 @@ function endTmdbMatching() {
   }
 }
 
-// Safety limits for EPG fetching
-// Large files (>50MB) cause UI freezing due to IPC overhead - TODO: implement streaming
-const MAX_COMPRESSED_SIZE_MB = 50;   // Max 50MB compressed (~500MB uncompressed)
-const MAX_COMPRESSED_BYTES = MAX_COMPRESSED_SIZE_MB * 1024 * 1024;
-
 // EPG Parser Web Worker - handles decompression and parsing off main thread
 let epgWorker: Worker | null = null;
+interface EpgParseResult {
+  programs: XmltvProgram[];
+  channels: XmltvChannel[];
+}
+
 let epgWorkerIdCounter = 0;
-const epgWorkerCallbacks = new Map<number, { resolve: (programs: XmltvProgram[]) => void; reject: (err: Error) => void }>();
+const epgWorkerCallbacks = new Map<number, { resolve: (result: EpgParseResult) => void; reject: (err: Error) => void }>();
 
 function getEpgWorker(): Worker {
   if (!epgWorker) {
     epgWorker = new Worker(new URL('../workers/epg-parser.worker.ts', import.meta.url), { type: 'module' });
     epgWorker.onmessage = (event) => {
-      const { type, id, programs, error } = event.data;
+      const { type, id, programs, channels, error } = event.data;
       const callback = epgWorkerCallbacks.get(id);
       if (callback) {
         epgWorkerCallbacks.delete(id);
         if (type === 'result') {
-          callback.resolve(programs || []);
+          callback.resolve({ programs: programs || [], channels: channels || [] });
         } else {
           callback.reject(new Error(error || 'Worker error'));
         }
@@ -108,58 +109,20 @@ function getEpgWorker(): Worker {
   return epgWorker;
 }
 
-// Convert string to Uint8Array in chunks (avoids blocking for large strings)
-async function stringToBufferChunked(str: string): Promise<Uint8Array> {
-  const encoder = new TextEncoder();
-  const CHUNK_SIZE = 1_000_000; // 1MB chunks
-
-  if (str.length <= CHUNK_SIZE) {
-    return encoder.encode(str);
-  }
-
-  // For large strings, encode in chunks with yields
-  const chunks: Uint8Array[] = [];
-  for (let i = 0; i < str.length; i += CHUNK_SIZE) {
-    const chunk = str.slice(i, i + CHUNK_SIZE);
-    chunks.push(encoder.encode(chunk));
-    // Yield to event loop
-    await new Promise(resolve => setTimeout(resolve, 0));
-  }
-
-  // Combine chunks
-  const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
-  }
-  return result;
-}
-
 // Parse EPG data using Web Worker (off main thread)
-// Uses Transferable for large data to avoid blocking structured clone
-async function parseEpgInWorker(data: string, isGzipped: boolean): Promise<XmltvProgram[]> {
-  return new Promise(async (resolve, reject) => {
+async function parseEpgInWorker(data: string, isGzipped: boolean): Promise<EpgParseResult> {
+  return new Promise((resolve, reject) => {
     const id = ++epgWorkerIdCounter;
     epgWorkerCallbacks.set(id, { resolve, reject });
-
-    // For large data, convert to ArrayBuffer and transfer (avoids copy)
-    if (data.length > 1_000_000) { // > 1MB
-      debugLog(`Large EPG data (${Math.round(data.length / 1024 / 1024)}MB), using chunked transfer...`, 'epg');
-      const buffer = await stringToBufferChunked(data);
-      getEpgWorker().postMessage(
-        { type: 'parse', id, buffer, isGzipped, isBuffer: true },
-        [buffer.buffer] // Transfer ownership
-      );
-    } else {
-      getEpgWorker().postMessage({ type: 'parse', id, data, isGzipped });
-    }
+    debugLog(`Sending ${Math.round(data.length / 1024 / 1024)}MB to worker for parsing...`, 'epg');
+    getEpgWorker().postMessage({ type: 'parse', id, data, isGzipped });
   });
 }
 
-// Fetch XMLTV from a single URL and parse it (parsing happens in worker)
-async function fetchXmltvFromUrl(epgUrl: string): Promise<XmltvProgram[]> {
+// Fetch XMLTV from a single URL and parse it
+// Gzipped/large files: fetched, decompressed, and parsed entirely in main process worker thread
+// Provider channels are passed for filtered parsing (skip programmes for non-matching channels)
+async function fetchXmltvFromUrl(epgUrl: string, providerChannels?: Channel[]): Promise<EpgParseResult> {
   const url = epgUrl.trim();
   debugLog(`Fetching XMLTV from: ${url}`, 'epg');
 
@@ -167,56 +130,61 @@ async function fetchXmltvFromUrl(epgUrl: string): Promise<XmltvProgram[]> {
     throw new Error('fetchProxy not available');
   }
 
-  // Handle gzipped files
+  // For gzipped files: fetch + decompress + parse all in main process
   if (url.endsWith('.gz')) {
-    debugLog('Detected gzipped file, fetching binary...', 'epg');
-    const response = await window.fetchProxy.fetchBinary(url);
+    debugLog('Using main process fetch+decompress+parse pipeline...', 'epg');
+    // Send minimal channel info for matching/filtering in the worker
+    const channelInfo = providerChannels?.map(ch => ({
+      epg_channel_id: ch.epg_channel_id,
+      name: ch.name,
+      stream_id: ch.stream_id,
+    }));
+    const response = await window.fetchProxy.fetchAndParseEpg(url, channelInfo);
     if (!response.data) {
-      throw new Error(`Failed to fetch gzipped XMLTV: ${response.error || 'unknown error'}`);
+      throw new Error(`Failed to fetch/parse XMLTV: ${response.error || 'unknown error'}`);
     }
-
-    // Check compressed size before processing (large files freeze UI)
-    const estimatedCompressedSize = Math.floor(response.data.length * 0.75);
-    if (estimatedCompressedSize > MAX_COMPRESSED_BYTES) {
-      const sizeMB = Math.round(estimatedCompressedSize / 1024 / 1024);
-      debugLog(`Skipping oversized EPG file: ${sizeMB}MB (max ${MAX_COMPRESSED_SIZE_MB}MB) - ${url}`, 'epg');
-      throw new Error(`EPG file too large (${sizeMB}MB). Use a regional EPG instead of ALL_SOURCES.`);
-    }
-
-    debugLog(`Received ${response.data.length} bytes (base64), sending to worker for decompression...`, 'epg');
-    const programs = await parseEpgInWorker(response.data, true);
-    debugLog(`Worker parsed ${programs.length} programs`, 'epg');
-    return programs;
-  } else {
-    const response = await window.fetchProxy.fetch(url);
-    if (!response.data?.ok) {
-      throw new Error(`Failed to fetch XMLTV: ${response.data?.status || 'unknown error'}`);
-    }
-    debugLog(`Received ${response.data.text.length} bytes, sending to worker for parsing...`, 'epg');
-    const programs = await parseEpgInWorker(response.data.text, false);
-    debugLog(`Worker parsed ${programs.length} programs`, 'epg');
-    return programs;
+    // Convert ISO strings back to Dates (Dates don't survive IPC)
+    const programs: XmltvProgram[] = response.data.programs.map(p => ({
+      channel_id: p.channel_id,
+      title: p.title,
+      description: p.description,
+      start: new Date(p.start),
+      stop: new Date(p.stop),
+    }));
+    debugLog(`Main process parsed ${response.data.channels.length} channels, ${programs.length} programs`, 'epg');
+    return { programs, channels: response.data.channels };
   }
+
+  // Plain XML: fetch via proxy, parse in web worker
+  const response = await window.fetchProxy.fetch(url);
+  if (!response.data?.ok) {
+    throw new Error(`Failed to fetch XMLTV: ${response.data?.status || 'unknown error'}`);
+  }
+  debugLog(`Got ${Math.round(response.data.text.length / 1024 / 1024)}MB XML, parsing in worker...`, 'epg');
+  const result = await parseEpgInWorker(response.data.text, false);
+  debugLog(`Worker parsed ${result.programs.length} programs, ${result.channels.length} EPG channels`, 'epg');
+  return result;
 }
 
 // Fetch XMLTV from potentially multiple URLs (comma-separated)
-async function fetchXmltvFromUrls(epgUrlStr: string): Promise<XmltvProgram[]> {
+async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[]): Promise<EpgParseResult> {
   // Split by comma and trim each URL
   const urls = epgUrlStr.split(',').map(u => u.trim()).filter(u => u.length > 0);
 
   if (urls.length === 0) {
-    return [];
+    return { programs: [], channels: [] };
   }
 
   if (urls.length === 1) {
-    return fetchXmltvFromUrl(urls[0]);
+    return fetchXmltvFromUrl(urls[0], providerChannels);
   }
 
   // Multiple URLs - fetch in parallel batches to avoid overwhelming servers
   // Yields to event loop between batches to keep UI responsive
   debugLog(`Found ${urls.length} EPG URLs, fetching in parallel batches...`, 'epg');
   const BATCH_SIZE = 5;
-  const allResults: XmltvProgram[][] = [];
+  const allPrograms: XmltvProgram[][] = [];
+  const allChannels: XmltvChannel[][] = [];
 
   for (let i = 0; i < urls.length; i += BATCH_SIZE) {
     const batch = urls.slice(i, i + BATCH_SIZE);
@@ -225,18 +193,19 @@ async function fetchXmltvFromUrls(epgUrlStr: string): Promise<XmltvProgram[]> {
     const results = await Promise.all(
       batch.map(async (url) => {
         try {
-          return await fetchXmltvFromUrl(url);
+          return await fetchXmltvFromUrl(url, providerChannels);
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
           debugLog(`Failed to fetch from ${url}: ${errMsg}`, 'epg');
-          return []; // Return empty array on failure, continue with others
+          return { programs: [], channels: [] } as EpgParseResult;
         }
       })
     );
 
     // Collect results without spreading (faster)
     for (const r of results) {
-      if (r.length > 0) allResults.push(r);
+      if (r.programs.length > 0) allPrograms.push(r.programs);
+      if (r.channels.length > 0) allChannels.push(r.channels);
     }
 
     // Yield to event loop between batches to keep UI responsive
@@ -244,9 +213,29 @@ async function fetchXmltvFromUrls(epgUrlStr: string): Promise<XmltvProgram[]> {
   }
 
   // Flatten at the end (single operation)
-  const allPrograms = allResults.flat();
-  debugLog(`Total programs from all EPG sources: ${allPrograms.length}`, 'epg');
-  return allPrograms;
+  const programs = allPrograms.flat();
+  const channels = allChannels.flat();
+  debugLog(`Total from all EPG sources: ${programs.length} programs, ${channels.length} channels`, 'epg');
+  return { programs, channels };
+}
+
+// Build a channelMap (xmltv_channel_id → stream_id) using EPG mappings + exact fallback
+function buildChannelMap(channels: Channel[], mappings: EpgMapping[]): Map<string, string> {
+  const channelMap = new Map<string, string>();
+
+  // Mappings take priority (fuzzy-matched channels)
+  for (const m of mappings) {
+    channelMap.set(m.xmltv_channel_id, m.stream_id);
+  }
+
+  // Also include exact epg_channel_id matches as fallback (provider's own EPG case)
+  for (const ch of channels) {
+    if (ch.epg_channel_id && !channelMap.has(ch.epg_channel_id)) {
+      channelMap.set(ch.epg_channel_id, ch.stream_id);
+    }
+  }
+
+  return channelMap;
 }
 
 // Sync EPG from XMLTV URL(s) for M3U sources
@@ -254,28 +243,33 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
   debugLog(`Starting M3U EPG sync`, 'epg');
 
   try {
-    const xmltvPrograms = await fetchXmltvFromUrls(epgUrl);
+    const { programs: xmltvPrograms, channels: xmltvChannels } = await fetchXmltvFromUrls(epgUrl, channels);
 
     if (xmltvPrograms.length === 0) {
       debugLog('No programs found in XMLTV, keeping existing data', 'epg');
       return 0;
     }
 
-    // Build a map of epg_channel_id -> stream_id for matching
-    const channelMap = new Map<string, string>();
-    let channelsWithEpgId = 0;
-    for (const ch of channels) {
-      if (ch.epg_channel_id) {
-        channelMap.set(ch.epg_channel_id, ch.stream_id);
-        channelsWithEpgId++;
+    // Run EPG channel matching and persist mappings
+    const mappings = matchChannelsToEpg(channels, xmltvChannels, source.id, epgUrl);
+    if (mappings.length > 0) {
+      const byStrategy = new Map<string, number>();
+      for (const m of mappings) {
+        byStrategy.set(m.strategy, (byStrategy.get(m.strategy) || 0) + 1);
       }
+      const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
+      debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
+      await db.epgMappings.bulkPut(mappings);
     }
-    debugLog(`${channelsWithEpgId}/${channels.length} channels have epg_channel_id`, 'epg');
+
+    // Build channel map from mappings + exact fallback
+    const channelMap = buildChannelMap(channels, mappings);
+    debugLog(`Channel map has ${channelMap.size} entries`, 'epg');
 
     // Convert XMLTV programs to stored format (yield periodically for large datasets)
     const storedPrograms: StoredProgram[] = [];
     const unmatchedChannels = new Set<string>();
-    const YIELD_EVERY = 10000; // Yield every 10k items
+    const YIELD_EVERY = 10000;
 
     for (let i = 0; i < xmltvPrograms.length; i++) {
       const prog = xmltvPrograms[i];
@@ -293,7 +287,6 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
       } else {
         unmatchedChannels.add(prog.channel_id);
       }
-      // Yield to event loop periodically
       if (i > 0 && i % YIELD_EVERY === 0) {
         await new Promise(resolve => setTimeout(resolve, 0));
       }
@@ -316,7 +309,6 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
     for (let i = 0; i < storedPrograms.length; i += BATCH_SIZE) {
       const batch = storedPrograms.slice(i, i + BATCH_SIZE);
       await db.programs.bulkPut(batch);
-      // Yield every few batches
       if ((i / BATCH_SIZE) % 10 === 0) {
         await new Promise(resolve => setTimeout(resolve, 0));
       }
@@ -343,26 +335,34 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<nu
   );
 
   try {
-    // Fetch full XMLTV data FIRST (don't delete old data until we have new)
+    // Fetch full XMLTV data with channel metadata
     debugLog('Fetching XMLTV data...', 'epg');
-    const xmltvPrograms = await client.getXmltvEpg();
-    debugLog(`Received ${xmltvPrograms.length} programs from XMLTV`, 'epg');
+    const { programs: xmltvPrograms, channels: xmltvChannels } = await client.getXmltvEpgFull();
+    debugLog(`Received ${xmltvPrograms.length} programs, ${xmltvChannels.length} EPG channels from XMLTV`, 'epg');
 
     if (xmltvPrograms.length === 0) {
       debugLog('No programs found in XMLTV, keeping existing data', 'epg');
       return 0;
     }
 
-    // Build a map of epg_channel_id -> stream_id for matching
-    const channelMap = new Map<string, string>();
-    let channelsWithEpgId = 0;
-    for (const ch of channels) {
-      if (ch.epg_channel_id) {
-        channelMap.set(ch.epg_channel_id, ch.stream_id);
-        channelsWithEpgId++;
+    // Determine EPG source URL for mapping key
+    const epgSource = `xtream://${source.url}`;
+
+    // Run EPG channel matching and persist mappings
+    const mappings = matchChannelsToEpg(channels, xmltvChannels, source.id, epgSource);
+    if (mappings.length > 0) {
+      const byStrategy = new Map<string, number>();
+      for (const m of mappings) {
+        byStrategy.set(m.strategy, (byStrategy.get(m.strategy) || 0) + 1);
       }
+      const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
+      debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
+      await db.epgMappings.bulkPut(mappings);
     }
-    debugLog(`${channelsWithEpgId}/${channels.length} channels have epg_channel_id`, 'epg');
+
+    // Build channel map from mappings + exact fallback
+    const channelMap = buildChannelMap(channels, mappings);
+    debugLog(`Channel map has ${channelMap.size} entries`, 'epg');
 
     // Convert XMLTV programs to stored format
     const storedPrograms: StoredProgram[] = [];
@@ -1030,4 +1030,38 @@ export async function syncAllVod(): Promise<Map<string, VodSyncResult>> {
   }
 
   return results;
+}
+
+// Re-match EPG for a source without full source re-sync
+// Use case: user added external EPG, matching was poor, EPG source updated
+export async function rematchEpg(source: Source): Promise<number> {
+  debugLog(`Starting EPG rematch for source: ${source.name || source.id}`, 'epg');
+
+  // Read current channels from DB
+  const channels = await db.channels.where('source_id').equals(source.id).toArray();
+  if (channels.length === 0) {
+    debugLog('No channels found for source, nothing to rematch', 'epg');
+    return 0;
+  }
+
+  // Clear existing mappings + programs for this source
+  await db.epgMappings.where('source_id').equals(source.id).delete();
+  await db.programs.where('source_id').equals(source.id).delete();
+
+  // Determine EPG URL
+  let programCount = 0;
+  if (source.epg_url) {
+    programCount = await syncEpgFromUrl(source, source.epg_url, channels);
+  } else if (source.type === 'xtream' && source.username && source.password) {
+    programCount = await syncEpgForSource(source, channels);
+  } else {
+    // Check if M3U had an EPG URL stored in meta
+    const meta = await db.sourcesMeta.get(source.id);
+    if (meta?.epg_url) {
+      programCount = await syncEpgFromUrl(source, meta.epg_url, channels);
+    }
+  }
+
+  debugLog(`EPG rematch complete: ${programCount} programs`, 'epg');
+  return programCount;
 }

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -16,6 +16,11 @@ function debugLog(message: string, category = 'sync'): void {
   }
 }
 
+interface EpgSyncResult {
+  count: number;
+  error?: string;
+}
+
 export interface SyncResult {
   success: boolean;
   channelCount: number;
@@ -79,9 +84,13 @@ interface EpgParseResult {
 }
 
 let epgWorkerIdCounter = 0;
+let epgWorkerCrashCount = 0;
 const epgWorkerCallbacks = new Map<number, { resolve: (result: EpgParseResult) => void; reject: (err: Error) => void }>();
 
 function getEpgWorker(): Worker {
+  if (epgWorkerCrashCount >= 3) {
+    throw new Error('EPG web worker crashed 3 times consecutively, giving up — restart the app to retry');
+  }
   if (!epgWorker) {
     epgWorker = new Worker(new URL('../workers/epg-parser.worker.ts', import.meta.url), { type: 'module' });
     epgWorker.onmessage = (event) => {
@@ -90,6 +99,7 @@ function getEpgWorker(): Worker {
       if (callback) {
         epgWorkerCallbacks.delete(id);
         if (type === 'result') {
+          epgWorkerCrashCount = 0; // Reset on success
           callback.resolve({ programs: programs || [], channels: channels || [] });
         } else {
           callback.reject(new Error(error || 'Worker error'));
@@ -97,7 +107,8 @@ function getEpgWorker(): Worker {
       }
     };
     epgWorker.onerror = (err) => {
-      debugLog(`EPG Worker error: ${err.message}`, 'epg');
+      epgWorkerCrashCount++;
+      debugLog(`EPG ERROR: Worker crashed (${epgWorkerCrashCount}/3): ${err.message}`, 'epg');
       // Reject all pending callbacks - worker is dead
       for (const [, callback] of epgWorkerCallbacks) {
         callback.reject(new Error(`EPG Worker crashed: ${err.message}`));
@@ -172,6 +183,7 @@ async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[
   const urls = epgUrlStr.split(',').map(u => u.trim()).filter(u => u.length > 0);
 
   if (urls.length === 0) {
+    debugLog('No valid EPG URLs found after parsing URL string', 'epg');
     return { programs: [], channels: [] };
   }
 
@@ -185,6 +197,7 @@ async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[
   const BATCH_SIZE = 5;
   const allPrograms: XmltvProgram[][] = [];
   const allChannels: XmltvChannel[][] = [];
+  const failedUrls: string[] = [];
 
   for (let i = 0; i < urls.length; i += BATCH_SIZE) {
     const batch = urls.slice(i, i + BATCH_SIZE);
@@ -196,7 +209,8 @@ async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[
           return await fetchXmltvFromUrl(url, providerChannels);
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
-          debugLog(`Failed to fetch from ${url}: ${errMsg}`, 'epg');
+          debugLog(`EPG ERROR: Failed to fetch from ${url}: ${errMsg}`, 'epg');
+          failedUrls.push(url);
           return { programs: [], channels: [] } as EpgParseResult;
         }
       })
@@ -215,6 +229,9 @@ async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[
   // Flatten at the end (single operation)
   const programs = allPrograms.flat();
   const channels = allChannels.flat();
+  if (failedUrls.length > 0) {
+    debugLog(`EPG WARNING: ${failedUrls.length}/${urls.length} EPG URLs failed: ${failedUrls.join(', ')}`, 'epg');
+  }
   debugLog(`Total from all EPG sources: ${programs.length} programs, ${channels.length} channels`, 'epg');
   return { programs, channels };
 }
@@ -239,7 +256,7 @@ function buildChannelMap(channels: Channel[], mappings: EpgMapping[]): Map<strin
 }
 
 // Sync EPG from XMLTV URL(s) for M3U sources
-async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[]): Promise<number> {
+async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[]): Promise<EpgSyncResult> {
   debugLog(`Starting M3U EPG sync`, 'epg');
 
   try {
@@ -247,7 +264,7 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
 
     if (xmltvPrograms.length === 0) {
       debugLog('No programs found in XMLTV, keeping existing data', 'epg');
-      return 0;
+      return { count: 0 };
     }
 
     // Run EPG channel matching and persist mappings
@@ -297,7 +314,7 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
     // SAFETY: Only clear old data if we have new data to replace it
     if (storedPrograms.length === 0) {
       debugLog('WARNING: No programs matched! Keeping existing EPG data to avoid data loss', 'epg');
-      return 0;
+      return { count: 0 };
     }
 
     // Clear old and store new
@@ -315,17 +332,17 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
     }
 
     debugLog(`M3U EPG sync complete: ${storedPrograms.length} programs stored`, 'epg');
-    return storedPrograms.length;
+    return { count: storedPrograms.length };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    debugLog(`M3U EPG fetch FAILED: ${errMsg}`, 'epg');
-    return 0;
+    debugLog(`EPG ERROR: M3U EPG fetch failed: ${errMsg}`, 'epg');
+    return { count: 0, error: errMsg };
   }
 }
 
 // Sync EPG for Xtream source using built-in endpoint
-async function syncEpgForSource(source: Source, channels: Channel[]): Promise<number> {
-  if (!source.username || !source.password) return 0;
+async function syncEpgForSource(source: Source, channels: Channel[]): Promise<EpgSyncResult> {
+  if (!source.username || !source.password) return { count: 0 };
 
   debugLog(`Starting EPG sync for source: ${source.name || source.id}`, 'epg');
 
@@ -342,7 +359,7 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<nu
 
     if (xmltvPrograms.length === 0) {
       debugLog('No programs found in XMLTV, keeping existing data', 'epg');
-      return 0;
+      return { count: 0 };
     }
 
     // Determine EPG source URL for mapping key
@@ -372,7 +389,7 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<nu
       const streamId = channelMap.get(prog.channel_id);
       if (streamId) {
         storedPrograms.push({
-          id: `${streamId}_${prog.start.getTime()}`,
+          id: `${source.id}-${streamId}-${prog.start.getTime()}`,
           stream_id: streamId,
           title: prog.title,
           description: prog.description,
@@ -390,7 +407,7 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<nu
     // SAFETY: Only clear old data if we have new data to replace it
     if (storedPrograms.length === 0) {
       debugLog('WARNING: No programs matched! Keeping existing EPG data to avoid data loss', 'epg');
-      return 0;
+      return { count: 0 };
     }
 
     // Clear old and store new
@@ -405,12 +422,12 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<nu
     }
 
     debugLog(`EPG sync complete: ${storedPrograms.length} programs stored`, 'epg');
-    return storedPrograms.length;
+    return { count: storedPrograms.length };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    debugLog(`EPG fetch FAILED: ${errMsg}`, 'epg');
+    debugLog(`EPG ERROR: Xtream EPG fetch failed: ${errMsg}`, 'epg');
     debugLog('Keeping existing EPG data', 'epg');
-    return 0;
+    return { count: 0, error: errMsg };
   }
 }
 
@@ -534,25 +551,32 @@ export async function syncSource(source: Source): Promise<SyncResult> {
 
     // Fetch EPG if enabled
     let programCount = 0;
+    let epgResult: EpgSyncResult = { count: 0 };
     const shouldLoadEpg = source.auto_load_epg ?? (source.type === 'xtream');
 
     if (shouldLoadEpg && source.type === 'xtream' && source.username && source.password) {
       // Xtream: use built-in EPG endpoint (or override if provided)
       debugLog('Syncing EPG for Xtream source...', 'epg');
-      programCount = await syncEpgForSource(source, channels);
-      debugLog(`EPG sync complete: ${programCount} programs`, 'epg');
+      epgResult = await syncEpgForSource(source, channels);
+      programCount = epgResult.count;
+      if (epgResult.error) debugLog(`EPG WARNING: sync completed with error: ${epgResult.error}`, 'epg');
+      else debugLog(`EPG sync complete: ${programCount} programs`, 'epg');
     } else if (shouldLoadEpg && epgUrl) {
       // M3U with EPG URL: fetch XMLTV from the EPG URL
       debugLog('Syncing EPG for M3U source...', 'epg');
-      programCount = await syncEpgFromUrl(source, epgUrl, channels);
-      debugLog(`M3U EPG sync complete: ${programCount} programs`, 'epg');
+      epgResult = await syncEpgFromUrl(source, epgUrl, channels);
+      programCount = epgResult.count;
+      if (epgResult.error) debugLog(`EPG WARNING: sync completed with error: ${epgResult.error}`, 'epg');
+      else debugLog(`M3U EPG sync complete: ${programCount} programs`, 'epg');
     }
 
     // If user provided a manual EPG URL override, use that
     if (source.epg_url && !shouldLoadEpg) {
       debugLog('Syncing EPG from manual URL override...', 'epg');
-      programCount = await syncEpgFromUrl(source, source.epg_url, channels);
-      debugLog(`Manual EPG sync complete: ${programCount} programs`, 'epg');
+      epgResult = await syncEpgFromUrl(source, source.epg_url, channels);
+      programCount = epgResult.count;
+      if (epgResult.error) debugLog(`EPG WARNING: manual sync completed with error: ${epgResult.error}`, 'epg');
+      else debugLog(`Manual EPG sync complete: ${programCount} programs`, 'epg');
     }
 
     debugLog(`Sync complete for ${source.name}: ${channels.length} channels, ${categories.length} categories, ${programCount} programs`, 'sync');
@@ -1049,19 +1073,20 @@ export async function rematchEpg(source: Source): Promise<number> {
   await db.programs.where('source_id').equals(source.id).delete();
 
   // Determine EPG URL
-  let programCount = 0;
+  let epgResult: EpgSyncResult = { count: 0 };
   if (source.epg_url) {
-    programCount = await syncEpgFromUrl(source, source.epg_url, channels);
+    epgResult = await syncEpgFromUrl(source, source.epg_url, channels);
   } else if (source.type === 'xtream' && source.username && source.password) {
-    programCount = await syncEpgForSource(source, channels);
+    epgResult = await syncEpgForSource(source, channels);
   } else {
     // Check if M3U had an EPG URL stored in meta
     const meta = await db.sourcesMeta.get(source.id);
     if (meta?.epg_url) {
-      programCount = await syncEpgFromUrl(source, meta.epg_url, channels);
+      epgResult = await syncEpgFromUrl(source, meta.epg_url, channels);
     }
   }
 
-  debugLog(`EPG rematch complete: ${programCount} programs`, 'epg');
-  return programCount;
+  if (epgResult.error) debugLog(`EPG WARNING: rematch completed with error: ${epgResult.error}`, 'epg');
+  debugLog(`EPG rematch complete: ${epgResult.count} programs`, 'epg');
+  return epgResult.count;
 }

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -109,13 +109,13 @@ function getEpgWorker(): Worker {
   return epgWorker;
 }
 
-// Parse EPG data using Web Worker (off main thread)
-async function parseEpgInWorker(data: string, isGzipped: boolean): Promise<EpgParseResult> {
+// Parse plain XML in Web Worker (off main thread)
+async function parseEpgInWorker(data: string): Promise<EpgParseResult> {
   return new Promise((resolve, reject) => {
     const id = ++epgWorkerIdCounter;
     epgWorkerCallbacks.set(id, { resolve, reject });
     debugLog(`Sending ${Math.round(data.length / 1024 / 1024)}MB to worker for parsing...`, 'epg');
-    getEpgWorker().postMessage({ type: 'parse', id, data, isGzipped });
+    getEpgWorker().postMessage({ type: 'parse', id, data });
   });
 }
 
@@ -161,7 +161,7 @@ async function fetchXmltvFromUrl(epgUrl: string, providerChannels?: Channel[]): 
     throw new Error(`Failed to fetch XMLTV: ${response.data?.status || 'unknown error'}`);
   }
   debugLog(`Got ${Math.round(response.data.text.length / 1024 / 1024)}MB XML, parsing in worker...`, 'epg');
-  const result = await parseEpgInWorker(response.data.text, false);
+  const result = await parseEpgInWorker(response.data.text);
   debugLog(`Worker parsed ${result.programs.length} programs, ${result.channels.length} EPG channels`, 'epg');
   return result;
 }

--- a/packages/ui/src/services/epg-matcher.ts
+++ b/packages/ui/src/services/epg-matcher.ts
@@ -2,18 +2,26 @@
  * EPG Channel Matcher - matches provider channels to external EPG channels
  *
  * Strategies (in priority order, first match wins per channel):
- * 1. Exact ID match
- * 2. Code extraction from EPG ID pattern Name(CODE).tld
- * 3. Display name match (normalized)
- * 4. Provider name → EPG code
- * 5. Slug match (normalized IDs)
- * 6. Provider base → EPG display names
- * 7-10. Loose variants (strip "the", "channel", "network", "tv")
+ *  1. exact_id        — Exact epg_channel_id match
+ *  2. code_match      — Provider EPG ID (base, no TLD) → extracted code from EPG ID parens
+ *  3. display_name    — Normalized provider name → EPG display name
+ *  4. name_code       — Normalized provider name → EPG code
+ *  5. slug_match      — Slugified provider EPG ID → slugified EPG ID
+ *  6. base_display    — Provider EPG ID (base) → EPG display name
+ *  7. loose_name      — Looser-normalized name → EPG loose name
+ *  8. loose_code      — Looser-normalized name → EPG code
+ *  9. base_loose      — Provider EPG ID (loose) → EPG loose name/slug
+ * 10. loose_looseslug — Looser name → EPG loose slug
+ * 11. callsign       — Call sign extraction ([KWCX]xxx, parens) → code map with DT variants
+ * 12. fuzzy          — Word-overlap + substring matching (0.6 threshold)
+ *
+ * Worker thread copy (epg-parse-worker.ts) duplicates strategies 1-12 because
+ * the worker can't import renderer modules. Keep both in sync.
  */
 
 import type { XmltvChannel } from '@sbtltv/local-adapter';
 import type { Channel } from '@sbtltv/core';
-import type { EpgMapping } from '../db/index';
+import type { EpgMapping, MatchStrategy } from '../db/index';
 
 /**
  * Normalize a channel name for fuzzy matching:
@@ -24,9 +32,7 @@ import type { EpgMapping } from '../db/index';
 function normalize(name: string): string {
   let s = name;
   s = s.replace(/^(USA?|UK|CA|AU|NZ|FR|DE|ES|IT|PT|NL|BE|AT|CH|IE|IN)\s*[:\-|]?\s*/i, '');
-  while (/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i.test(s)) {
-    s = s.replace(/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i, '');
-  }
+  s = s.replace(/([\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*))+\s*$/i, '');
   s = s.toLowerCase();
   s = s.replace(/&/g, 'and').replace(/\+/g, 'plus');
   return s.replace(/[^a-z0-9]/g, '');
@@ -35,7 +41,9 @@ function normalize(name: string): string {
 function normalizeLooser(name: string): string {
   let s = normalize(name);
   s = s.replace(/^the/, '');
-  s = s.replace(/(channel|network|television|tv)$/, '');
+  s = s.replace(/(channel|network|television)$/, '');
+  // Only strip trailing "tv" if preceded by 3+ chars (avoid mangling acronyms like MTV, CTV, ATV)
+  s = s.replace(/(?<=.{3})tv$/, '');
   return s;
 }
 
@@ -46,7 +54,7 @@ function extractCodes(epgId: string): string[] {
 }
 
 function slugify(id: string): string {
-  return id.replace(/\.\w{2,3}$/, '').replace(/\([^)]*\)/, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  return id.replace(/\.\w{2,3}$/, '').replace(/\([^)]*\)/g, '').toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 function stripTld(id: string): string {
@@ -78,6 +86,8 @@ export function matchChannelsToEpg(
     exactMap.set(xch.id, xch.id);
     for (const code of extractCodes(xch.id)) {
       codeMap.set(code, xch.id);
+      // US/CA local stations use DT (digital television) suffix in XMLTV (e.g. "wabcdt"),
+      // but providers use bare call signs ("wabc"). Map base call to catch these.
       const dtMatch = code.match(/^(.+?)dt(\d?)$/);
       if (dtMatch) {
         const baseCall = dtMatch[1];
@@ -101,7 +111,7 @@ export function matchChannelsToEpg(
     }
   }
 
-  function addMapping(ch: Channel, xmltvId: string, confidence: 'exact' | 'high' | 'medium', strategy: string) {
+  function addMapping(ch: Channel, xmltvId: string, confidence: 'exact' | 'high' | 'medium', strategy: MatchStrategy) {
     if (matched.has(ch.stream_id)) return;
     matched.add(ch.stream_id);
     mappings.push({
@@ -115,6 +125,8 @@ export function matchChannelsToEpg(
       strategy,
     });
   }
+
+  const callsignSkip = new Set(['USA', 'UHD', 'WEST', 'EAST', 'COZI', 'CBSN', 'CSPAN', 'CNBC', 'CMT', 'CNN', 'CBS', 'CMA', 'CITY', 'CRIME', 'WORLD', 'CGTN', 'WWE', 'NBC', 'ABC', 'FOX', 'PBS', 'CW']);
 
   for (const ch of channels) {
     if (matched.has(ch.stream_id)) continue;
@@ -159,14 +171,13 @@ export function matchChannelsToEpg(
     if (loose) { const ls = looseSlugMap.get(loose); if (ls) { addMapping(ch, ls, 'medium', 'loose_looseslug'); continue; } }
     // Strategy 11: Extract call signs from channel name
     {
-      const skip = new Set(['USA', 'UHD', 'WEST', 'EAST', 'COZI', 'CBSN', 'CSPAN', 'CNBC', 'CMT', 'CNN', 'CBS', 'CMA', 'CITY', 'CRIME', 'WORLD', 'CGTN', 'WWE', 'NBC', 'ABC', 'FOX', 'PBS', 'CW']);
       const parenMatches = ch.name.match(/\(([A-Z][A-Z0-9\-]{2,8})\)/g) || [];
       const parenSigns = parenMatches.map(s => s.slice(1, -1).replace(/-/g, ''));
       const textSigns = ch.name.match(/\b([KWCX][A-Z]{2,4}(?:-?DT\d?)?)\b/g) || [];
       const allSigns = [...parenSigns, ...textSigns.map(s => s.replace(/-/g, ''))];
 
       for (const sign of allSigns) {
-        if (skip.has(sign) || sign.length < 3) continue;
+        if (callsignSkip.has(sign) || sign.length < 3) continue;
         const code = sign.toLowerCase();
         const cm = codeMap.get(code)
           || codeMap.get(code + 'dt')
@@ -174,6 +185,61 @@ export function matchChannelsToEpg(
         if (cm) { addMapping(ch, cm, 'medium', 'callsign'); break; }
       }
       if (matched.has(ch.stream_id)) continue;
+    }
+  }
+
+  // Strategy 12: Lightweight fuzzy fallback — word overlap + substring matching
+  {
+    const wordIndex = new Map<string, Set<string>>();
+    for (const xch of xmltvChannels) {
+      for (const dn of xch.displayNames) {
+        const words = normalize(dn).match(/[a-z]{3,}/g) || [];
+        for (const w of words) {
+          if (!wordIndex.has(w)) wordIndex.set(w, new Set());
+          wordIndex.get(w)!.add(xch.id);
+        }
+      }
+    }
+
+    const epgNormById = new Map<string, string>();
+    for (const xch of xmltvChannels) {
+      if (xch.displayNames.length > 0) {
+        epgNormById.set(xch.id, normalize(xch.displayNames[0]));
+      }
+    }
+
+    for (const ch of channels) {
+      if (matched.has(ch.stream_id)) continue;
+      const norm = normalize(ch.name);
+      if (!norm || norm.length < 4) continue;
+      const words = norm.match(/[a-z]{3,}/g) || [];
+      if (words.length === 0) continue;
+
+      const candidates = new Map<string, number>();
+      for (const w of words) {
+        const ids = wordIndex.get(w);
+        if (ids) {
+          for (const id of ids) candidates.set(id, (candidates.get(id) || 0) + 1);
+        }
+      }
+
+      let bestId: string | null = null;
+      let bestScore = 0;
+      for (const [id, wordOverlap] of candidates) {
+        if (wordOverlap < Math.max(1, words.length * 0.4)) continue;
+        const epgNorm = epgNormById.get(id);
+        if (!epgNorm) continue;
+        const shorter = norm.length < epgNorm.length ? norm : epgNorm;
+        const longer = norm.length >= epgNorm.length ? norm : epgNorm;
+        if (longer.includes(shorter) || shorter.includes(longer)) {
+          const score = shorter.length / longer.length;
+          if (score > bestScore && score >= 0.6) { bestScore = score; bestId = id; }
+        }
+      }
+
+      if (bestId) {
+        addMapping(ch, bestId, 'medium', 'fuzzy');
+      }
     }
   }
 

--- a/packages/ui/src/services/epg-matcher.ts
+++ b/packages/ui/src/services/epg-matcher.ts
@@ -1,0 +1,181 @@
+/**
+ * EPG Channel Matcher - matches provider channels to external EPG channels
+ *
+ * Strategies (in priority order, first match wins per channel):
+ * 1. Exact ID match
+ * 2. Code extraction from EPG ID pattern Name(CODE).tld
+ * 3. Display name match (normalized)
+ * 4. Provider name → EPG code
+ * 5. Slug match (normalized IDs)
+ * 6. Provider base → EPG display names
+ * 7-10. Loose variants (strip "the", "channel", "network", "tv")
+ */
+
+import type { XmltvChannel } from '@sbtltv/local-adapter';
+import type { Channel } from '@sbtltv/core';
+import type { EpgMapping } from '../db/index';
+
+/**
+ * Normalize a channel name for fuzzy matching:
+ * - Strip country prefixes (USA, US:, UK:, etc.)
+ * - Strip quality suffixes (HD, UHD, FHD, SD, East, West, *)
+ * - Lowercase, remove non-alphanumeric
+ */
+function normalize(name: string): string {
+  let s = name;
+  s = s.replace(/^(USA?|UK|CA|AU|NZ|FR|DE|ES|IT|PT|NL|BE|AT|CH|IE|IN)\s*[:\-|]?\s*/i, '');
+  while (/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i.test(s)) {
+    s = s.replace(/[\s*]*(L?HD|UHD|FHD|SD|4K|East|West|\+1|\*)\s*$/i, '');
+  }
+  s = s.toLowerCase();
+  s = s.replace(/&/g, 'and').replace(/\+/g, 'plus');
+  return s.replace(/[^a-z0-9]/g, '');
+}
+
+function normalizeLooser(name: string): string {
+  let s = normalize(name);
+  s = s.replace(/^the/, '');
+  s = s.replace(/(channel|network|television|tv)$/, '');
+  return s;
+}
+
+function extractCodes(epgId: string): string[] {
+  const matches = epgId.match(/\(([^)]+)\)/g);
+  if (!matches) return [];
+  return matches.map(m => m.slice(1, -1).toLowerCase());
+}
+
+function slugify(id: string): string {
+  return id.replace(/\.\w{2,3}$/, '').replace(/\([^)]*\)/, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function stripTld(id: string): string {
+  return id.replace(/\.\w{2,3}$/, '').toLowerCase();
+}
+
+/**
+ * Match provider channels to XMLTV EPG channels.
+ * Returns mappings for all matched channels.
+ * All lookups are Map-based → O(N+M) total.
+ */
+export function matchChannelsToEpg(
+  channels: Channel[],
+  xmltvChannels: XmltvChannel[],
+  sourceId: string,
+  epgSource: string,
+): EpgMapping[] {
+  const mappings: EpgMapping[] = [];
+  const matched = new Set<string>();
+
+  const exactMap = new Map<string, string>();
+  const codeMap = new Map<string, string>();
+  const displayNameMap = new Map<string, string>();
+  const slugMap = new Map<string, string>();
+  const looseNameMap = new Map<string, string>();
+  const looseSlugMap = new Map<string, string>();
+
+  for (const xch of xmltvChannels) {
+    exactMap.set(xch.id, xch.id);
+    for (const code of extractCodes(xch.id)) {
+      codeMap.set(code, xch.id);
+      const dtMatch = code.match(/^(.+?)dt(\d?)$/);
+      if (dtMatch) {
+        const baseCall = dtMatch[1];
+        const dtNum = dtMatch[2];
+        if (!dtNum || !codeMap.has(baseCall)) {
+          codeMap.set(baseCall, xch.id);
+        }
+      }
+    }
+    for (const dn of xch.displayNames) {
+      const norm = normalize(dn);
+      if (norm) displayNameMap.set(norm, xch.id);
+      const loose = normalizeLooser(dn);
+      if (loose) looseNameMap.set(loose, xch.id);
+    }
+    const slug = slugify(xch.id);
+    if (slug) {
+      slugMap.set(slug, xch.id);
+      const looseSlug = slug.replace(/(channel|network|television|tv)$/, '');
+      if (looseSlug) looseSlugMap.set(looseSlug, xch.id);
+    }
+  }
+
+  function addMapping(ch: Channel, xmltvId: string, confidence: 'exact' | 'high' | 'medium', strategy: string) {
+    if (matched.has(ch.stream_id)) return;
+    matched.add(ch.stream_id);
+    mappings.push({
+      id: `${sourceId}::${epgSource}::${ch.epg_channel_id}`,
+      source_id: sourceId,
+      epg_channel_id: ch.epg_channel_id,
+      xmltv_channel_id: xmltvId,
+      epg_source: epgSource,
+      stream_id: ch.stream_id,
+      confidence,
+      strategy,
+    });
+  }
+
+  for (const ch of channels) {
+    if (matched.has(ch.stream_id)) continue;
+    const norm = normalize(ch.name);
+    const loose = normalizeLooser(ch.name);
+
+    // Strategy 1: Exact ID
+    if (ch.epg_channel_id) {
+      const ex = exactMap.get(ch.epg_channel_id);
+      if (ex) { addMapping(ch, ex, 'exact', 'exact_id'); continue; }
+      // Strategy 2: Provider base → EPG code
+      const base = stripTld(ch.epg_channel_id);
+      if (base) { const cm = codeMap.get(base); if (cm) { addMapping(ch, cm, 'high', 'code_match'); continue; } }
+    }
+    // Strategy 3: Display name
+    if (norm) { const dm = displayNameMap.get(norm); if (dm) { addMapping(ch, dm, 'high', 'display_name'); continue; } }
+    // Strategy 4: Name → code
+    if (norm) { const cm2 = codeMap.get(norm); if (cm2) { addMapping(ch, cm2, 'high', 'name_code'); continue; } }
+    // Strategy 5: Slug match
+    if (ch.epg_channel_id) {
+      const slug = slugify(ch.epg_channel_id);
+      if (slug) { const sm = slugMap.get(slug); if (sm) { addMapping(ch, sm, 'high', 'slug_match'); continue; } }
+    }
+    // Strategy 6: Provider base → EPG display names
+    if (ch.epg_channel_id) {
+      const base = stripTld(ch.epg_channel_id);
+      if (base) { const dm2 = displayNameMap.get(base); if (dm2) { addMapping(ch, dm2, 'high', 'base_display'); continue; } }
+    }
+    // Strategy 7: Loose name match
+    if (loose) { const lm = looseNameMap.get(loose); if (lm) { addMapping(ch, lm, 'medium', 'loose_name'); continue; } }
+    // Strategy 8: Loose name → code
+    if (loose) { const lc = codeMap.get(loose); if (lc) { addMapping(ch, lc, 'medium', 'loose_code'); continue; } }
+    // Strategy 9: Provider base (loose) → EPG loose names/slugs
+    if (ch.epg_channel_id) {
+      const baseLo = normalizeLooser(stripTld(ch.epg_channel_id));
+      if (baseLo) {
+        const bl = looseNameMap.get(baseLo); if (bl) { addMapping(ch, bl, 'medium', 'base_loose'); continue; }
+        const bls = looseSlugMap.get(baseLo); if (bls) { addMapping(ch, bls, 'medium', 'base_looseslug'); continue; }
+      }
+    }
+    // Strategy 10: Loose name → loose slug
+    if (loose) { const ls = looseSlugMap.get(loose); if (ls) { addMapping(ch, ls, 'medium', 'loose_looseslug'); continue; } }
+    // Strategy 11: Extract call signs from channel name
+    {
+      const skip = new Set(['USA', 'UHD', 'WEST', 'EAST', 'COZI', 'CBSN', 'CSPAN', 'CNBC', 'CMT', 'CNN', 'CBS', 'CMA', 'CITY', 'CRIME', 'WORLD', 'CGTN', 'WWE', 'NBC', 'ABC', 'FOX', 'PBS', 'CW']);
+      const parenMatches = ch.name.match(/\(([A-Z][A-Z0-9\-]{2,8})\)/g) || [];
+      const parenSigns = parenMatches.map(s => s.slice(1, -1).replace(/-/g, ''));
+      const textSigns = ch.name.match(/\b([KWCX][A-Z]{2,4}(?:-?DT\d?)?)\b/g) || [];
+      const allSigns = [...parenSigns, ...textSigns.map(s => s.replace(/-/g, ''))];
+
+      for (const sign of allSigns) {
+        if (skip.has(sign) || sign.length < 3) continue;
+        const code = sign.toLowerCase();
+        const cm = codeMap.get(code)
+          || codeMap.get(code + 'dt')
+          || (code.match(/dt\d?$/) ? codeMap.get(code.replace(/dt\d?$/, '')) : null);
+        if (cm) { addMapping(ch, cm, 'medium', 'callsign'); break; }
+      }
+      if (matched.has(ch.stream_id)) continue;
+    }
+  }
+
+  return mappings;
+}

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -110,7 +110,6 @@ export interface FetchProxyResponse {
 export interface FetchProxyApi {
   fetch: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => Promise<StorageResult<FetchProxyResponse>>;
   fetchBinary: (url: string) => Promise<StorageResult<string>>; // Returns base64-encoded data
-  fetchAndDecompress: (url: string) => Promise<StorageResult<string>>; // Fetches + gunzips in main, returns text
   fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) => Promise<StorageResult<{ channels: { id: string; displayNames: string[] }[]; programs: { channel_id: string; title: string; description: string; start: string; stop: string }[] }>>;
 }
 

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -110,6 +110,8 @@ export interface FetchProxyResponse {
 export interface FetchProxyApi {
   fetch: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => Promise<StorageResult<FetchProxyResponse>>;
   fetchBinary: (url: string) => Promise<StorageResult<string>>; // Returns base64-encoded data
+  fetchAndDecompress: (url: string) => Promise<StorageResult<string>>; // Fetches + gunzips in main, returns text
+  fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) => Promise<StorageResult<{ channels: { id: string; displayNames: string[] }[]; programs: { channel_id: string; title: string; description: string; start: string; stop: string }[] }>>;
 }
 
 export interface PlatformApi {

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -110,6 +110,8 @@ export interface FetchProxyResponse {
 export interface FetchProxyApi {
   fetch: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => Promise<StorageResult<FetchProxyResponse>>;
   fetchBinary: (url: string) => Promise<StorageResult<string>>; // Returns base64-encoded data
+  // Provider channel shape must match ProviderChannelInfo in main.ts and ProviderChannel in epg-parse-worker.ts
+  // Return shape must match EpgChannel/EpgProgram in epg-parse-worker.ts (dates are ISO strings over IPC)
   fetchAndParseEpg: (url: string, providerChannels?: { epg_channel_id: string; name: string; stream_id: string }[]) => Promise<StorageResult<{ channels: { id: string; displayNames: string[] }[]; programs: { channel_id: string; title: string; description: string; start: string; stop: string }[] }>>;
 }
 

--- a/packages/ui/src/workers/epg-parser.worker.ts
+++ b/packages/ui/src/workers/epg-parser.worker.ts
@@ -3,7 +3,7 @@
  * Handles decompression and parsing of XMLTV data off the main thread
  */
 
-import { parseXmltv, type XmltvProgram } from '@sbtltv/local-adapter';
+import { parseXmltvFull, type XmltvProgram, type XmltvChannel } from '@sbtltv/local-adapter';
 
 export interface EpgWorkerMessage {
   type: 'parse';
@@ -18,20 +18,49 @@ export interface EpgWorkerResponse {
   type: 'result' | 'error';
   id: number;
   programs?: XmltvProgram[];
+  channels?: XmltvChannel[];
   error?: string;
+}
+
+// Decode base64 to Uint8Array in chunks (avoids atob on huge strings)
+function base64ToBytes(base64: string): Uint8Array {
+  // Use built-in atob but in manageable chunks to avoid string size limits
+  const CHUNK_CHARS = 4 * 256 * 1024; // Must be multiple of 4 for base64
+  const chunks: Uint8Array[] = [];
+  let totalLen = 0;
+
+  for (let i = 0; i < base64.length; i += CHUNK_CHARS) {
+    const slice = base64.slice(i, i + CHUNK_CHARS);
+    const bin = atob(slice);
+    const bytes = new Uint8Array(bin.length);
+    for (let j = 0; j < bin.length; j++) {
+      bytes[j] = bin.charCodeAt(j);
+    }
+    chunks.push(bytes);
+    totalLen += bytes.length;
+  }
+
+  if (chunks.length === 1) return chunks[0];
+
+  const result = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
 }
 
 // Decompress gzipped data
 async function decompressGzip(base64Data: string): Promise<string> {
-  const binaryString = atob(base64Data);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
+  console.log(`[epg-worker] base64ToBytes starting (${Math.round(base64Data.length / 1024 / 1024)}MB)...`);
+  const bytes = base64ToBytes(base64Data);
+  console.log(`[epg-worker] Got ${Math.round(bytes.length / 1024 / 1024)}MB binary, decompressing...`);
 
   const ds = new DecompressionStream('gzip');
-  const decompressedStream = new Blob([bytes]).stream().pipeThrough(ds);
+  const decompressedStream = new Blob([bytes.buffer as ArrayBuffer]).stream().pipeThrough(ds);
   const decompressedBlob = await new Response(decompressedStream).blob();
+  console.log(`[epg-worker] Decompressed blob: ${Math.round(decompressedBlob.size / 1024 / 1024)}MB`);
   return await decompressedBlob.text();
 }
 
@@ -45,10 +74,13 @@ self.onmessage = async (event: MessageEvent<EpgWorkerMessage>) => {
 
     // Get the data - either from transferred buffer or string
     let inputData: string;
+    console.log(`[epg-worker] Received message: isBuffer=${isBuffer}, bufferLen=${buffer?.byteLength}, dataLen=${data?.length}, isGzipped=${isGzipped}`);
     if (isBuffer && buffer) {
       // Decode transferred buffer back to string
+      console.log(`[epg-worker] Decoding transferred buffer (${Math.round(buffer.byteLength / 1024 / 1024)}MB)...`);
       const decoder = new TextDecoder();
       inputData = decoder.decode(buffer);
+      console.log(`[epg-worker] Decoded to ${Math.round(inputData.length / 1024 / 1024)}MB string`);
     } else if (data) {
       inputData = data;
     } else {
@@ -56,17 +88,25 @@ self.onmessage = async (event: MessageEvent<EpgWorkerMessage>) => {
     }
 
     if (isGzipped) {
+      console.log(`[epg-worker] Decompressing gzipped data (${Math.round(inputData.length / 1024 / 1024)}MB input)...`);
       xmlText = await decompressGzip(inputData);
+      console.log(`[epg-worker] Decompressed to ${Math.round(xmlText.length / 1024 / 1024)}MB XML`);
+      if (xmlText.length > 0) {
+        console.log(`[epg-worker] First 200 chars: ${xmlText.slice(0, 200)}`);
+      }
     } else {
       xmlText = inputData;
     }
 
-    const programs = parseXmltv(xmlText);
+    console.log(`[epg-worker] Parsing ${Math.round(xmlText.length / 1024 / 1024)}MB XML...`);
+    const result = parseXmltvFull(xmlText);
+    console.log(`[epg-worker] Parsed: ${result.programs.length} programs, ${result.channels.length} channels`);
 
     self.postMessage({
       type: 'result',
       id,
-      programs,
+      programs: result.programs,
+      channels: result.channels,
     } as EpgWorkerResponse);
   } catch (err) {
     self.postMessage({

--- a/packages/ui/src/workers/epg-parser.worker.ts
+++ b/packages/ui/src/workers/epg-parser.worker.ts
@@ -1,6 +1,7 @@
 /**
  * EPG Parser Web Worker
- * Handles decompression and parsing of XMLTV data off the main thread
+ * Parses plain XMLTV text off the main thread.
+ * Gzipped files are handled by the main process worker thread instead.
  */
 
 import { parseXmltvFull, type XmltvProgram, type XmltvChannel } from '@sbtltv/local-adapter';
@@ -8,10 +9,7 @@ import { parseXmltvFull, type XmltvProgram, type XmltvChannel } from '@sbtltv/lo
 export interface EpgWorkerMessage {
   type: 'parse';
   id: number;
-  data?: string;        // Raw XML text or base64 gzipped data
-  buffer?: Uint8Array;  // Transferred buffer (for large data)
-  isBuffer?: boolean;   // True if using buffer instead of string
-  isGzipped: boolean;
+  data: string;
 }
 
 export interface EpgWorkerResponse {
@@ -22,85 +20,13 @@ export interface EpgWorkerResponse {
   error?: string;
 }
 
-// Decode base64 to Uint8Array in chunks (avoids atob on huge strings)
-function base64ToBytes(base64: string): Uint8Array {
-  // Use built-in atob but in manageable chunks to avoid string size limits
-  const CHUNK_CHARS = 4 * 256 * 1024; // Must be multiple of 4 for base64
-  const chunks: Uint8Array[] = [];
-  let totalLen = 0;
-
-  for (let i = 0; i < base64.length; i += CHUNK_CHARS) {
-    const slice = base64.slice(i, i + CHUNK_CHARS);
-    const bin = atob(slice);
-    const bytes = new Uint8Array(bin.length);
-    for (let j = 0; j < bin.length; j++) {
-      bytes[j] = bin.charCodeAt(j);
-    }
-    chunks.push(bytes);
-    totalLen += bytes.length;
-  }
-
-  if (chunks.length === 1) return chunks[0];
-
-  const result = new Uint8Array(totalLen);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
-  }
-  return result;
-}
-
-// Decompress gzipped data
-async function decompressGzip(base64Data: string): Promise<string> {
-  console.log(`[epg-worker] base64ToBytes starting (${Math.round(base64Data.length / 1024 / 1024)}MB)...`);
-  const bytes = base64ToBytes(base64Data);
-  console.log(`[epg-worker] Got ${Math.round(bytes.length / 1024 / 1024)}MB binary, decompressing...`);
-
-  const ds = new DecompressionStream('gzip');
-  const decompressedStream = new Blob([bytes.buffer as ArrayBuffer]).stream().pipeThrough(ds);
-  const decompressedBlob = await new Response(decompressedStream).blob();
-  console.log(`[epg-worker] Decompressed blob: ${Math.round(decompressedBlob.size / 1024 / 1024)}MB`);
-  return await decompressedBlob.text();
-}
-
 self.onmessage = async (event: MessageEvent<EpgWorkerMessage>) => {
-  const { type, id, data, buffer, isBuffer, isGzipped } = event.data;
+  const { type, id, data } = event.data;
 
   if (type !== 'parse') return;
 
   try {
-    let xmlText: string;
-
-    // Get the data - either from transferred buffer or string
-    let inputData: string;
-    console.log(`[epg-worker] Received message: isBuffer=${isBuffer}, bufferLen=${buffer?.byteLength}, dataLen=${data?.length}, isGzipped=${isGzipped}`);
-    if (isBuffer && buffer) {
-      // Decode transferred buffer back to string
-      console.log(`[epg-worker] Decoding transferred buffer (${Math.round(buffer.byteLength / 1024 / 1024)}MB)...`);
-      const decoder = new TextDecoder();
-      inputData = decoder.decode(buffer);
-      console.log(`[epg-worker] Decoded to ${Math.round(inputData.length / 1024 / 1024)}MB string`);
-    } else if (data) {
-      inputData = data;
-    } else {
-      throw new Error('No data provided');
-    }
-
-    if (isGzipped) {
-      console.log(`[epg-worker] Decompressing gzipped data (${Math.round(inputData.length / 1024 / 1024)}MB input)...`);
-      xmlText = await decompressGzip(inputData);
-      console.log(`[epg-worker] Decompressed to ${Math.round(xmlText.length / 1024 / 1024)}MB XML`);
-      if (xmlText.length > 0) {
-        console.log(`[epg-worker] First 200 chars: ${xmlText.slice(0, 200)}`);
-      }
-    } else {
-      xmlText = inputData;
-    }
-
-    console.log(`[epg-worker] Parsing ${Math.round(xmlText.length / 1024 / 1024)}MB XML...`);
-    const result = parseXmltvFull(xmlText);
-    console.log(`[epg-worker] Parsed: ${result.programs.length} programs, ${result.channels.length} channels`);
+    const result = parseXmltvFull(data);
 
     self.postMessage({
       type: 'result',


### PR DESCRIPTION
## Summary

Adds persistent EPG mapping and multi-strategy channel matching so external EPG sources (epg.pw, etc.) work alongside provider EPGs. Previously, EPG matching required exact ID equality — this adds fuzzy matching, call sign extraction, and a streaming parser that handles multi-GB files.

- **11 matching strategies** from exact ID through fuzzy word-overlap fallback
- **Stream-based XMLTV parser** in a worker thread — constant memory, handles 4GB+ files
- **Filtered parsing** — only processes programmes for matched channels, skipping 90%+ of data
- **Dexie v12** — `epgMappings` table for persistent channel-to-EPG mappings

## Review Sections

### 1. XMLTV Parser Rewrite (`local-adapter/src/xmltv-parser.ts`)
- Replaced regex-based parser with indexOf-based scanning (regex silently failed on 500MB+ strings)
- Added `parseXmltvFull()` returning both channels and programmes
- `channelsDone` optimization prevents re-scanning entire buffer after channel section
- Added `XmltvChannel`, `XmltvParseResult` types + exports from `index.ts`

### 2. Main Process EPG Pipeline (`electron/src/main.ts`)
- New `fetch-and-parse-epg` IPC handler: download → stream decompress → worker thread parse
- `downloadToTempFile()`: streams response to disk (no ArrayBuffer size limits)
- `decompressToFile()`: streams gunzip to temp file (handles 4GB+ decompressed)
- `parseEpgInWorkerThread()`: spawns worker with 8GB heap limit
- Provider channel info passed through for filtered parsing

### 3. Stream Parser Worker (`electron/src/epg-parse-worker.ts`, **new file**)
- Worker thread with `createReadStream` + chunk-based XML parsing
- Two-phase: scans channels first, runs matching, then filters programmes
- 11 matching strategies: exact ID, code extraction (multi-paren), display name, slug, loose variants, call sign extraction from names, word-overlap fuzzy fallback
- Matching helpers duplicated from `epg-matcher.ts` (worker can't import renderer modules)
- DT/DT2/DT3 suffix handling for local station call signs

### 4. EPG Channel Matcher (`ui/src/services/epg-matcher.ts`, **new file**)
- Same matching strategies as the worker (used by Xtream sync path + mapping persistence)
- Normalize: strips country prefixes, quality suffixes, `&→and`/`+→plus`
- `normalizeLooser`: additionally strips "the", "channel", "network", "tv"
- `extractCodes`: handles multiple parenthesized groups in EPG IDs
- Call sign extraction: parens + `[KWCX]` text pattern, DT suffix variants

### 5. Database & Sync Changes (`ui/src/db/index.ts`, `ui/src/db/sync.ts`)
- **Dexie v12**: `epgMappings` table with `[source_id+epg_source]` compound index
- `EpgMapping` interface: source_id, stream_id, xmltv_channel_id, confidence, strategy
- `clearSourceData/clearAllCachedData/purgeOrphanedData` updated to include epgMappings
- `syncEpgFromUrl`: uses `fetchAndParseEpg` for .gz files, web worker for plain XML
- `syncEpgForSource` (Xtream): uses `getXmltvEpgFull()` + matching
- `buildChannelMap()`: merges mapping results with exact-match fallback
- `rematchEpg()`: re-run matching without full source re-sync
- `fetchXmltvFromUrls`: passes provider channels through for filtered parsing

### 6. Web Worker Simplification (`ui/src/workers/epg-parser.worker.ts`)
- Stripped base64/gzip decompression (now handled by main process)
- Only handles plain XML text parsing via `parseXmltvFull`

### 7. Xtream Client Extension (`local-adapter/src/xtream-client.ts`)
- Added `getXmltvEpgFull()` returning `XmltvParseResult` (channels + programmes)

## Test plan
- [ ] Add Xtream source → sync → provider's own EPG still works (exact match path)
- [ ] Add external .gz EPG URL → sync matches channels, programmes appear in grid
- [ ] Add large EPG (1GB+) → no crash, UI stays responsive during parse
- [ ] Re-sync same source → mappings rebuilt cleanly (clearSourceData wipes old ones)
- [ ] Switch EPG URLs → no orphaned mappings
- [ ] Delete source → all mappings cleaned up
- [ ] Check Dexie DevTools: `epgMappings` table has entries with confidence levels
- [ ] Verify programme data appears for channels that previously had no EPG