### PR TITLE
feat(ui): fullscreen toggle + category scroll-to-top (0.8.0 polish)

### DIFF
--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -230,6 +230,9 @@ async function createWindow(): Promise<void> {
     mainWindow = null;
     killMpv();
   });
+
+  mainWindow.on('enter-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', true));
+  mainWindow.on('leave-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', false));
 }
 
 function killMpv(): void {
@@ -763,6 +766,11 @@ ipcMain.handle('window-set-size', (_event, width: number, height: number) => {
   // Use setBounds which seems to work in both directions
   const bounds = mainWindow.getBounds();
   mainWindow.setBounds({ x: bounds.x, y: bounds.y, width: newW, height: newH });
+});
+
+ipcMain.handle('window-set-fullscreen', () => {
+  if (!mainWindow) return;
+  mainWindow.setFullScreen(!mainWindow.isFullScreen());
 });
 
 // IPC Handlers - mpv control

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -46,6 +46,9 @@ export interface ElectronWindowApi {
   close: () => Promise<void>;
   getSize: () => Promise<[number, number]>;
   setSize: (width: number, height: number) => Promise<void>;
+  setFullscreen: () => Promise<void>;
+  onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => void;
+  removeFullscreenListener: () => void;
 }
 
 export interface StorageResult<T = void> {
@@ -114,6 +117,13 @@ contextBridge.exposeInMainWorld('electronWindow', {
   close: () => ipcRenderer.invoke('window-close'),
   getSize: () => ipcRenderer.invoke('window-get-size'),
   setSize: (width: number, height: number) => ipcRenderer.invoke('window-set-size', width, height),
+  setFullscreen: () => ipcRenderer.invoke('window-set-fullscreen'),
+  onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => {
+    ipcRenderer.on('window-fullscreen-changed', (_event: IpcRendererEvent, data: boolean) => callback(data));
+  },
+  removeFullscreenListener: () => {
+    ipcRenderer.removeAllListeners('window-fullscreen-changed');
+  },
 } satisfies ElectronWindowApi);
 
 // Expose mpv API to the renderer process

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -122,6 +122,9 @@ contextBridge.exposeInMainWorld('electronWindow', {
     ipcRenderer.on('window-fullscreen-changed', (_event: IpcRendererEvent, data: boolean) => callback(data));
   },
   removeFullscreenListener: () => {
+    // NOTE: channel-global removeAllListeners (matches the mpv/updater pattern). Fine while App is
+    // the only subscriber; if a second component ever listens on this channel, switch to a stored
+    // callback + ipcRenderer.removeListener so this cleanup doesn't clobber the other subscriber.
     ipcRenderer.removeAllListeners('window-fullscreen-changed');
   },
 } satisfies ElectronWindowApi);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -661,15 +661,19 @@ function App() {
 
   return (
     <div className={`app${showControls ? '' : ' controls-hidden'}`} onMouseMove={handleMouseMove}>
-      {/* Custom title bar for frameless window */}
-      <div className={`title-bar${showControls && !isFullscreen ? ' visible' : ''}`}>
+      {/* Custom title bar for frameless window — stays available in fullscreen (auto-hides on idle) */}
+      <div className={`title-bar${showControls ? ' visible' : ''}`}>
         <Logo className="title-bar-logo" />
         <div className="window-controls">
           <button onClick={handleMinimize} title="Minimize">
             ─
           </button>
-          <button onClick={handleMaximize} title="Maximize">
-            □
+          {/* In fullscreen, maximize is meaningless (and flaky on macOS), so the button exits fullscreen */}
+          <button
+            onClick={isFullscreen ? handleToggleFullscreen : handleMaximize}
+            title={isFullscreen ? 'Exit fullscreen' : 'Maximize'}
+          >
+            {isFullscreen ? '❐' : '□'}
           </button>
           <button onClick={handleClose} className="close" title="Close">
             ✕

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -154,6 +154,9 @@ function App() {
   const autoplayEnabled = useAutoplayNextEpisode();
   const autoplayEnabledRef = useRef(autoplayEnabled);
   const loadTokenRef = useRef(0);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const isFullscreenRef = useRef(isFullscreen);
+  const [channelScrollNonce, setChannelScrollNonce] = useState(0);
   // Resolve the next-episode VodPlayInfo for the currently-playing series episode (null if none).
   const resolveNextEpisodeInfo = useCallback(async (cur: VodPlayInfo): Promise<VodPlayInfo | null> => {
     if (cur.type !== 'series' || cur.seasonNum == null || cur.episodeNum == null) {
@@ -181,6 +184,7 @@ function App() {
   const triggerUpNextRef = useRef(triggerUpNext);
   useEffect(() => { triggerUpNextRef.current = triggerUpNext; }, [triggerUpNext]);
   useEffect(() => { autoplayEnabledRef.current = autoplayEnabled; }, [autoplayEnabled]);
+  useEffect(() => { isFullscreenRef.current = isFullscreen; }, [isFullscreen]);
 
   // Track volume slider dragging to ignore mpv updates during drag
   const volumeDraggingRef = useRef(false);
@@ -455,6 +459,10 @@ function App() {
 
   // Handle category selection - opens guide if closed
   const handleSelectCategory = (catId: string | null) => {
+    if (catId === categoryId && activeView === 'guide') {
+      setChannelScrollNonce((n) => n + 1);   // already viewing this category in the open guide → scroll to top
+      return;
+    }
     setCategoryId(catId);
     // Open guide if it's not already open
     if (activeView !== 'guide') {
@@ -599,6 +607,13 @@ function App() {
           e.preventDefault();
           handleTogglePlay();
           break;
+        case 'f':
+          handleToggleFullscreen();
+          break;
+        case 'F11':
+          e.preventDefault();
+          handleToggleFullscreen();
+          break;
         case 'm':
           handleToggleMute();
           break;
@@ -611,6 +626,10 @@ function App() {
           setCategoriesOpen((open) => !open);
           break;
         case 'Escape':
+          if (isFullscreenRef.current) {
+            handleToggleFullscreen();   // exit fullscreen first (exit-only)
+            break;
+          }
           setActiveView('none');
           setCategoriesOpen(false);
           setShowControls(false);
@@ -622,15 +641,22 @@ function App() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  // Subscribe to OS fullscreen state (source of truth for the button icon + Esc logic)
+  useEffect(() => {
+    window.electronWindow?.onFullscreenChanged?.(setIsFullscreen);
+    return () => window.electronWindow?.removeFullscreenListener?.();
+  }, []);
+
   // Window control handlers
   const handleMinimize = () => window.electronWindow?.minimize();
   const handleMaximize = () => window.electronWindow?.maximize();
   const handleClose = () => window.electronWindow?.close();
+  const handleToggleFullscreen = () => window.electronWindow?.setFullscreen();
 
   return (
     <div className={`app${showControls ? '' : ' controls-hidden'}`} onMouseMove={handleMouseMove}>
       {/* Custom title bar for frameless window */}
-      <div className={`title-bar${showControls ? ' visible' : ''}`}>
+      <div className={`title-bar${showControls && !isFullscreen ? ' visible' : ''}`}>
         <Logo className="title-bar-logo" />
         <div className="window-controls">
           <button onClick={handleMinimize} title="Minimize">
@@ -704,6 +730,8 @@ function App() {
         onMouseLeave={() => { controlsHoveredRef.current = false; }}
         onNextEpisode={handleNextEpisode}
         showNextEpisode={vodInfo?.type === 'series'}
+        isFullscreen={isFullscreen}
+        onToggleFullscreen={handleToggleFullscreen}
       />
 
       {upNext && (
@@ -743,6 +771,7 @@ function App() {
         sidebarExpanded={sidebarExpanded}
         onPlayChannel={handlePlayChannel}
         onClose={() => setActiveView('none')}
+        scrollTopNonce={channelScrollNonce}
       />
 
       {/* Settings Panel */}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -598,7 +598,7 @@ function App() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Don't handle shortcuts when typing in inputs
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLSelectElement) {
         return;
       }
 
@@ -627,7 +627,8 @@ function App() {
           break;
         case 'Escape':
           if (isFullscreenRef.current) {
-            handleToggleFullscreen();   // exit fullscreen first (exit-only)
+            e.stopImmediatePropagation();   // exit fullscreen only — don't also close an open detail/panel
+            handleToggleFullscreen();
             break;
           }
           setActiveView('none');
@@ -651,7 +652,12 @@ function App() {
   const handleMinimize = () => window.electronWindow?.minimize();
   const handleMaximize = () => window.electronWindow?.maximize();
   const handleClose = () => window.electronWindow?.close();
-  const handleToggleFullscreen = () => window.electronWindow?.setFullscreen();
+  const handleToggleFullscreen = () => {
+    // Linux runs mpv in its own window (with its own `f` fullscreen), so toggling the Electron
+    // window here would fullscreen the chrome, not the video — no-op on Linux.
+    if (window.platform?.isLinux) return;
+    window.electronWindow?.setFullscreen();
+  };
 
   return (
     <div className={`app${showControls ? '' : ' controls-hidden'}`} onMouseMove={handleMouseMove}>
@@ -731,7 +737,7 @@ function App() {
         onNextEpisode={handleNextEpisode}
         showNextEpisode={vodInfo?.type === 'series'}
         isFullscreen={isFullscreen}
-        onToggleFullscreen={handleToggleFullscreen}
+        onToggleFullscreen={window.platform?.isLinux ? undefined : handleToggleFullscreen}
       />
 
       {upNext && (
@@ -799,7 +805,7 @@ function App() {
       {/* Resize grip for frameless window — Electron frameless windows lack native resize edges */}
       {(window.platform?.isWindows || window.platform?.isLinux) && (
       <div
-        className={`resize-grip${showControls ? ' visible' : ''}`}
+        className={`resize-grip${showControls && !isFullscreen ? ' visible' : ''}`}
         onMouseDown={(e) => {
           e.preventDefault();
           if (!window.electronWindow) return;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -665,9 +665,12 @@ function App() {
       <div className={`title-bar${showControls ? ' visible' : ''}`}>
         <Logo className="title-bar-logo" />
         <div className="window-controls">
-          <button onClick={handleMinimize} title="Minimize">
-            ─
-          </button>
+          {/* macOS can't minimize a window in a native fullscreen space — hide it there */}
+          {!(isFullscreen && window.platform?.isMac) && (
+            <button onClick={handleMinimize} title="Minimize">
+              ─
+            </button>
+          )}
           {/* In fullscreen, maximize is meaningless (and flaky on macOS), so the button exits fullscreen */}
           <button
             onClick={isFullscreen ? handleToggleFullscreen : handleMaximize}

--- a/packages/ui/src/components/ChannelPanel.tsx
+++ b/packages/ui/src/components/ChannelPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { Virtuoso } from 'react-virtuoso';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { useChannels, useCategories, useProgramsInRange } from '../hooks/useChannels';
 import { useFavoriteChannels } from '../hooks/useFavorites';
 import { useTimeGrid } from '../hooks/useTimeGrid';
@@ -18,6 +18,7 @@ interface ChannelPanelProps {
   sidebarExpanded: boolean;
   onPlayChannel: (channel: StoredChannel) => void;
   onClose: () => void;
+  scrollTopNonce?: number;
 }
 
 export function ChannelPanel({
@@ -27,6 +28,7 @@ export function ChannelPanel({
   sidebarExpanded,
   onPlayChannel,
   onClose,
+  scrollTopNonce,
 }: ChannelPanelProps) {
   const channelSortOrder = useChannelSortOrder();
   const isFavoritesView = categoryId === '__favorites__';
@@ -39,6 +41,13 @@ export function ChannelPanel({
 
   // Ref for measuring the grid container width
   const gridContainerRef = useRef<HTMLDivElement>(null);
+  // Ref to the channel-list Virtuoso for scroll-to-top on active-category re-click
+  const channelListRef = useRef<VirtuosoHandle>(null);
+
+  // Scroll the channel list to top when the active category is re-clicked (nonce bump)
+  useEffect(() => {
+    channelListRef.current?.scrollToIndex({ index: 0 });
+  }, [scrollTopNonce]);
 
   // Track window width to differentiate window resize vs category toggle
   const lastWindowWidth = useRef(typeof window !== 'undefined' ? window.innerWidth : 0);
@@ -255,6 +264,7 @@ export function ChannelPanel({
       {/* EPG Grid Area */}
       <div className="guide-content">
         <Virtuoso
+          ref={channelListRef}
           data={channels}
           className="guide-channels"
           itemContent={(index, channel) => (

--- a/packages/ui/src/components/NowPlayingBar.tsx
+++ b/packages/ui/src/components/NowPlayingBar.tsx
@@ -347,15 +347,16 @@ export function NowPlayingBar({
               >
                 <StopIcon />
               </button>
-              <button
-                className="npb-btn"
-                onClick={onToggleFullscreen}
-                disabled={!onToggleFullscreen}
-                title={isFullscreen ? 'Exit fullscreen (f)' : 'Fullscreen (f)'}
-                aria-label="Toggle fullscreen"
-              >
-                {isFullscreen ? <ExitFullscreenIcon /> : <FullscreenIcon />}
-              </button>
+              {onToggleFullscreen && (
+                <button
+                  className="npb-btn"
+                  onClick={onToggleFullscreen}
+                  title={isFullscreen ? 'Exit fullscreen (f)' : 'Fullscreen (f)'}
+                  aria-label="Toggle fullscreen"
+                >
+                  {isFullscreen ? <ExitFullscreenIcon /> : <FullscreenIcon />}
+                </button>
+              )}
             </div>
 
             {/* Volume controls */}

--- a/packages/ui/src/components/NowPlayingBar.tsx
+++ b/packages/ui/src/components/NowPlayingBar.tsx
@@ -27,6 +27,8 @@ interface NowPlayingBarProps {
   onMouseLeave?: () => void;
   onNextEpisode?: () => void;
   showNextEpisode?: boolean;
+  isFullscreen?: boolean;
+  onToggleFullscreen?: () => void;
 }
 
 // Format seconds to "H:MM:SS" or "M:SS"
@@ -63,6 +65,8 @@ export function NowPlayingBar({
   onMouseLeave,
   onNextEpisode,
   showNextEpisode,
+  isFullscreen,
+  onToggleFullscreen,
 }: NowPlayingBarProps) {
   const canControl = mpvReady && channel !== null;
   const currentProgram = useCurrentProgram(channel?.stream_id ?? null);
@@ -343,6 +347,15 @@ export function NowPlayingBar({
               >
                 <StopIcon />
               </button>
+              <button
+                className="npb-btn"
+                onClick={onToggleFullscreen}
+                disabled={!onToggleFullscreen}
+                title={isFullscreen ? 'Exit fullscreen (f)' : 'Fullscreen (f)'}
+                aria-label="Toggle fullscreen"
+              >
+                {isFullscreen ? <ExitFullscreenIcon /> : <FullscreenIcon />}
+              </button>
             </div>
 
             {/* Volume controls */}
@@ -414,6 +427,22 @@ function StopIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
       <rect x="6" y="6" width="12" height="12" rx="1" />
+    </svg>
+  );
+}
+
+function FullscreenIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M4 4h6v2H6v4H4V4zm10 0h6v6h-2V6h-4V4zM4 14h2v4h4v2H4v-6zm16 0h-2v4h-4v2h6v-6z" />
+    </svg>
+  );
+}
+
+function ExitFullscreenIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M10 4H8v4H4v2h6V4zm6 0h-2v6h6V8h-4V4zM8 14H4v2h4v4h2v-6H8zm8 0h-2v6h2v-4h4v-2h-4z" />
     </svg>
   );
 }

--- a/packages/ui/src/components/VodPage.tsx
+++ b/packages/ui/src/components/VodPage.tsx
@@ -176,6 +176,7 @@ export function VodPage({ type, onPlay, onClose }: VodPageProps) {
 
   // Local selected item state, initialized from store
   const [selectedItem, setSelectedItem] = useState<MediaItem | null>(detailItem);
+  const [scrollTopNonce, setScrollTopNonce] = useState(0);
 
   // Sync selected item back to store
   useEffect(() => {
@@ -372,9 +373,13 @@ export function VodPage({ type, onPlay, onClose }: VodPageProps) {
 
   // Handle category selection - also close detail view
   const handleCategorySelect = useCallback((id: string | null) => {
-    setSelectedCategoryId(id);
     setSelectedItem(null);
-  }, [setSelectedCategoryId]);
+    if (id === selectedCategoryId) {
+      setScrollTopNonce((n) => n + 1);   // re-click active category → scroll grid to top
+    } else {
+      setSelectedCategoryId(id);
+    }
+  }, [selectedCategoryId, setSelectedCategoryId, setSelectedItem]);
 
   // Handle mouse back button and browser back - close detail view
   useEffect(() => {
@@ -447,6 +452,7 @@ export function VodPage({ type, onPlay, onClose }: VodPageProps) {
             categoryIds={null}
             categoryName={`All ${typeLabel}`}
             search={searchQuery || undefined}
+            scrollTopNonce={scrollTopNonce}
             onItemClick={handleItemClick}
           />
         ) : selectedCategoryId && selectedGroup ? (
@@ -456,6 +462,7 @@ export function VodPage({ type, onPlay, onClose }: VodPageProps) {
             categoryIds={selectedCategoryIds}
             categoryName={selectedGroup.name}
             search={searchQuery || undefined}
+            scrollTopNonce={scrollTopNonce}
             onItemClick={handleItemClick}
           />
         ) : (

--- a/packages/ui/src/components/vod/VodBrowse.tsx
+++ b/packages/ui/src/components/vod/VodBrowse.tsx
@@ -65,6 +65,7 @@ export interface VodBrowseProps {
   categoryIds: string[] | null;  // null = all items, array = grouped category IDs
   categoryName: string;
   search?: string;
+  scrollTopNonce?: number;  // bump to force a scroll-to-top (re-click of active category)
   onItemClick: (item: StoredMovie | StoredSeries) => void;
 }
 
@@ -73,6 +74,7 @@ export function VodBrowse({
   categoryIds,
   categoryName,
   search,
+  scrollTopNonce,
   onItemClick,
 }: VodBrowseProps) {
   const virtuosoRef = useRef<VirtuosoGridHandle>(null);
@@ -85,12 +87,12 @@ export function VodBrowse({
   // Stable key for category changes (scroll to top)
   const categoryKey = categoryIds?.join(',') ?? null;
 
-  // Scroll to top when category changes
+  // Scroll to top when category changes OR when the active category is re-clicked (scrollTopNonce bump)
   useEffect(() => {
     if (virtuosoRef.current) {
       virtuosoRef.current.scrollToIndex({ index: 0, align: 'start' });
     }
-  }, [categoryKey]);
+  }, [categoryKey, scrollTopNonce]);
 
   // Get paginated data (using debounced search)
   const moviesData = usePaginatedMovies(type === 'movies' ? categoryIds : null, debouncedSearch);

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -44,6 +44,9 @@ export interface ElectronWindowApi {
   close: () => Promise<void>;
   getSize: () => Promise<[number, number]>;
   setSize: (width: number, height: number) => Promise<void>;
+  setFullscreen: () => Promise<void>;
+  onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => void;
+  removeFullscreenListener: () => void;
 }
 
 export interface StorageResult<T = void> {


### PR DESCRIPTION
## Summary

0.8.0 polish bundle (feature #1 of 2). Two small desktop wins:

- **Fullscreen toggle** (#63, + fullscreen half of #61): `f` / `F11` / a new NowPlayingBar button toggle **true OS fullscreen** (`BrowserWindow.setFullScreen`). `Esc` exits. The custom frameless title bar is hidden while fullscreen.
- **Category scroll-to-top** (#62): re-clicking the already-active category scrolls the list back to the top — on both the live channel list and the VOD grid.

## How it works

- New `window-set-fullscreen` IPC toggles `setFullScreen`; `enter/leave-full-screen` → a `window-fullscreen-changed` event drives the button icon + `Esc` logic (OS is the source of truth, not optimistic renderer state).
- Scroll-to-top via a `scrollTopNonce` prop bumped on active-category re-click; reuses each list's Virtuoso `scrollToIndex(0)`. The live path preserves its existing open-guide-on-select behavior.

## Decisions

- True `setFullScreen` (covers taskbar/dock) chosen over the existing maximize toggle.
- `Esc` is **exit-only** (one layer per press); open detail panels still self-close via their own `Esc` listeners.
- Hide the custom title bar in fullscreen — no new CSS, just don't apply the `visible` class while fullscreen.
- Arrow-key seek **deferred** (kept scope tight; revisit on demand).

## Testing

- ✅ `pnpm -r typecheck` — clean across all 5 packages
- ✅ `pnpm --filter @sbtltv/ui test` — 108/108 pass, no regressions
- ⏳ Device-verify pending (Windows local build): f/F11/button enter+exit fullscreen, title bar hidden, NowPlayingBar still appears on mouse-move, `Esc` exits, re-click active category scrolls both lists to top, `.npb-controls` doesn't clip with the new button
- ⏳ **Mac**: native fullscreen with the frameless window needs the GH Actions test build (`build-test.yml`)

## Risk

- Mac native fullscreen + frameless (`frame: false`) window — the one thing to confirm on the Mac test build before merge.

---

8 files changed (+104 / −6). Design spec + implementation plan: `thoughts/shared/{specs,plans}/2026-06-01-fullscreen-scroll*` (local, gitignored).
