### PR TITLE
feat(toast): toast system + removing-account progress + curated errors (0.8.0)

### DIFF
--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -231,8 +231,16 @@ async function createWindow(): Promise<void> {
     killMpv();
   });
 
-  mainWindow.on('enter-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', true));
-  mainWindow.on('leave-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', false));
+  // Drive the renderer's "fullscreen" state (button icon + Esc-to-exit). macOS uses true OS
+  // fullscreen events; Windows/Linux use maximize state (setFullScreen is unreliable on the
+  // transparent window, so "fullscreen" == maximize there).
+  if (process.platform === 'darwin') {
+    mainWindow.on('enter-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', true));
+    mainWindow.on('leave-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', false));
+  } else {
+    mainWindow.on('maximize', () => mainWindow?.webContents.send('window-fullscreen-changed', true));
+    mainWindow.on('unmaximize', () => mainWindow?.webContents.send('window-fullscreen-changed', false));
+  }
 }
 
 function killMpv(): void {
@@ -770,7 +778,17 @@ ipcMain.handle('window-set-size', (_event, width: number, height: number) => {
 
 ipcMain.handle('window-set-fullscreen', () => {
   if (!mainWindow) return;
-  mainWindow.setFullScreen(!mainWindow.isFullScreen());
+  if (process.platform === 'darwin') {
+    // macOS: opaque window + native mpv texture — true OS fullscreen works.
+    mainWindow.setFullScreen(!mainWindow.isFullScreen());
+  } else {
+    // Windows/Linux: window is transparent (external mpv renders behind) and Electron's
+    // setFullScreen is unreliable on transparent windows — maximize is the working equivalent.
+    // (A "real" taskbar-covering Windows fullscreen would need the transparent/external-mpv
+    // model reworked; deferred.)
+    if (mainWindow.isMaximized()) mainWindow.unmaximize();
+    else mainWindow.maximize();
+  }
 });
 
 // IPC Handlers - mpv control

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -9,6 +9,8 @@ import { MoviesPage } from './components/MoviesPage';
 import { SeriesPage } from './components/SeriesPage';
 import { Logo } from './components/Logo';
 import { UpdateNotification } from './components/UpdateNotification';
+import { ToastContainer } from './components/toast/ToastContainer';
+import { useToastStore } from './stores/toastStore';
 import { VideoCanvas } from './components/VideoCanvas';
 import { useSelectedCategory } from './hooks/useChannels';
 import { useCssVariableSync } from './hooks/useCssVariableSync';
@@ -586,6 +588,7 @@ function App() {
         const errMsg = err instanceof Error ? err.message : String(err);
         debugLog(`Initial sync failed: ${errMsg}`, 'sync');
         console.error('[App] Initial sync failed:', err);
+        useToastStore.getState().addToast({ kind: 'error', title: 'Sync failed', message: errMsg, duration: 6000 });
       } finally {
         setChannelSyncing(false);
         setVodSyncing(false);
@@ -808,6 +811,9 @@ function App() {
 
       {/* Update notification toast */}
       <UpdateNotification />
+
+      {/* Transient toast stack */}
+      <ToastContainer />
 
       {/* Resize grip for frameless window — Electron frameless windows lack native resize edges */}
       {(window.platform?.isWindows || window.platform?.isLinux) && (

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -8,7 +8,6 @@ import { ChannelPanel } from './components/ChannelPanel';
 import { MoviesPage } from './components/MoviesPage';
 import { SeriesPage } from './components/SeriesPage';
 import { Logo } from './components/Logo';
-import { UpdateNotification } from './components/UpdateNotification';
 import { ToastContainer } from './components/toast/ToastContainer';
 import { useToastStore } from './stores/toastStore';
 import { VideoCanvas } from './components/VideoCanvas';
@@ -588,7 +587,7 @@ function App() {
         const errMsg = err instanceof Error ? err.message : String(err);
         debugLog(`Initial sync failed: ${errMsg}`, 'sync');
         console.error('[App] Initial sync failed:', err);
-        useToastStore.getState().addToast({ kind: 'error', title: 'Sync failed', message: errMsg, duration: 6000 });
+        useToastStore.getState().addToast({ kind: 'error', title: 'Sync failed', message: 'Check the source and your connection — details are in the debug log.', duration: 8000 });
       } finally {
         setChannelSyncing(false);
         setVodSyncing(false);
@@ -809,10 +808,7 @@ function App() {
         />
       )}
 
-      {/* Update notification toast */}
-      <UpdateNotification />
-
-      {/* Transient toast stack */}
+      {/* Notification stack: the sticky update chip anchors the bottom; transient toasts stack above it */}
       <ToastContainer />
 
       {/* Resize grip for frameless window — Electron frameless windows lack native resize edges */}

--- a/packages/ui/src/components/UpdateNotification.css
+++ b/packages/ui/src/components/UpdateNotification.css
@@ -1,8 +1,5 @@
 .update-notification {
-  position: fixed;
-  bottom: 97px;
-  right: 24px;
-  z-index: 9999;
+  /* Positioned by the shared .toast-container (bottom-right stack); not fixed itself. */
   background: #1a1a1a;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 6px;

--- a/packages/ui/src/components/settings/SourcesTab.tsx
+++ b/packages/ui/src/components/settings/SourcesTab.tsx
@@ -6,6 +6,7 @@ import { clearSourceData, clearVodData, db } from '../../db';
 import { useSyncStatus } from '../../hooks/useChannels';
 import { useChannelSyncing, useSetChannelSyncing, useVodSyncing, useSetVodSyncing, useUIStore, useUpdateSettings } from '../../stores/uiStore';
 import { parseM3U } from '@sbtltv/local-adapter';
+import { useToast } from '../../hooks/useToast';
 
 interface SourcesTabProps {
   sources: Source[];
@@ -40,6 +41,7 @@ export function SourcesTab({ sources, isEncryptionAvailable, onSourcesChange }: 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [formData, setFormData] = useState<SourceFormData>(emptyForm);
   const [error, setError] = useState<string | null>(null);
+  const toast = useToast();
   const [syncError, setSyncError] = useState<string | null>(null);
   const syncStatus = useSyncStatus();
 
@@ -132,28 +134,35 @@ export function SourcesTab({ sources, isEncryptionAvailable, onSourcesChange }: 
     );
     if (!confirmed) return;
 
-    // Mark source as deleted FIRST - prevents sync from writing results after deletion
-    markSourceDeleted(id);
+    const p = toast.progress(`Removing ${sourceName}…`);
+    try {
+      // Mark source as deleted FIRST - prevents sync from writing results after deletion
+      markSourceDeleted(id);
 
-    // Clean up all data in IndexedDB before removing source config
-    await clearSourceData(id);
-    await clearVodData(id);
-    await window.storage.deleteSource(id);
+      // Clean up all data in IndexedDB before removing source config
+      await clearSourceData(id);
+      await clearVodData(id);
+      await window.storage.deleteSource(id);
 
-    // Clean deleted source from priority order lists
-    const { liveSourceOrder: lso, vodSourceOrder: vso } = useUIStore.getState().settings;
-    const cleanedLive = lso?.filter(sid => sid !== id);
-    const cleanedVod = vso?.filter(sid => sid !== id);
-    if (cleanedLive) {
-      updateSettings({ liveSourceOrder: cleanedLive });
-      window.storage?.updateSettings({ liveSourceOrder: cleanedLive });
+      // Clean deleted source from priority order lists
+      const { liveSourceOrder: lso, vodSourceOrder: vso } = useUIStore.getState().settings;
+      const cleanedLive = lso?.filter(sid => sid !== id);
+      const cleanedVod = vso?.filter(sid => sid !== id);
+      if (cleanedLive) {
+        updateSettings({ liveSourceOrder: cleanedLive });
+        window.storage?.updateSettings({ liveSourceOrder: cleanedLive });
+      }
+      if (cleanedVod) {
+        updateSettings({ vodSourceOrder: cleanedVod });
+        window.storage?.updateSettings({ vodSourceOrder: cleanedVod });
+      }
+
+      onSourcesChange();
+      p.succeed(`Removed ${sourceName}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      p.fail(`Couldn't remove ${sourceName}`, msg);
     }
-    if (cleanedVod) {
-      updateSettings({ vodSourceOrder: cleanedVod });
-      window.storage?.updateSettings({ vodSourceOrder: cleanedVod });
-    }
-
-    onSourcesChange();
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -197,6 +206,7 @@ export function SourcesTab({ sources, isEncryptionAvailable, onSourcesChange }: 
 
     // Append new source to priority order lists (only for new sources, not edits)
     if (!editingId) {
+      toast.success(`Added ${source.name}`);
       const { liveSourceOrder: lso, vodSourceOrder: vso } = useUIStore.getState().settings;
       if (lso && lso.length > 0) {
         const newLive = [...lso, sourceId];

--- a/packages/ui/src/components/settings/SourcesTab.tsx
+++ b/packages/ui/src/components/settings/SourcesTab.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { Source } from '../../types/electron';
-import { syncAllSources, syncAllVod, markSourceDeleted } from '../../db/sync';
+import { syncAllSources, syncAllVod, markSourceDeleted, unmarkSourceDeleted } from '../../db/sync';
 import { clearSourceData, clearVodData, db } from '../../db';
 import { useSyncStatus } from '../../hooks/useChannels';
 import { useChannelSyncing, useSetChannelSyncing, useVodSyncing, useSetVodSyncing, useUIStore, useUpdateSettings } from '../../stores/uiStore';
@@ -135,6 +135,7 @@ export function SourcesTab({ sources, isEncryptionAvailable, onSourcesChange }: 
     if (!confirmed) return;
 
     const p = toast.progress(`Removing ${sourceName}…`);
+    const startedAt = Date.now();
     try {
       // Mark source as deleted FIRST - prevents sync from writing results after deletion
       markSourceDeleted(id);
@@ -142,7 +143,8 @@ export function SourcesTab({ sources, isEncryptionAvailable, onSourcesChange }: 
       // Clean up all data in IndexedDB before removing source config
       await clearSourceData(id);
       await clearVodData(id);
-      await window.storage.deleteSource(id);
+      const result = await window.storage.deleteSource(id);
+      if (result.error) throw new Error(result.error); // soft IPC error — surface as a failure
 
       // Clean deleted source from priority order lists
       const { liveSourceOrder: lso, vodSourceOrder: vso } = useUIStore.getState().settings;
@@ -158,8 +160,13 @@ export function SourcesTab({ sources, isEncryptionAvailable, onSourcesChange }: 
       }
 
       onSourcesChange();
+      // Keep the branded loader visible briefly even when the purge is near-instant.
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < 500) await new Promise((r) => setTimeout(r, 500 - elapsed));
       p.succeed(`Removed ${sourceName}`);
     } catch (err) {
+      // Deletion failed part-way — un-suppress sync for this still-present source.
+      unmarkSourceDeleted(id);
       const msg = err instanceof Error ? err.message : String(err);
       p.fail(`Couldn't remove ${sourceName}`, msg);
     }

--- a/packages/ui/src/components/toast/SbtlLoader.tsx
+++ b/packages/ui/src/components/toast/SbtlLoader.tsx
@@ -1,0 +1,10 @@
+import { SbtlMark } from '../SbtlMark';
+
+/**
+ * Branded loading indicator: the "sbtl" letterforms doing a sequential pop.
+ * `SbtlMark` intrinsic size is 410×185 (viewBox "310 248 410 185"); `size` is the width in px.
+ * The animation lives in Toast.css (`.sbtl-loader path:nth-of-type(1..4)`).
+ */
+export function SbtlLoader({ size = 30 }: { size?: number }) {
+  return <SbtlMark className="sbtl-loader" width={size} height={Math.round((size * 185) / 410)} />;
+}

--- a/packages/ui/src/components/toast/Toast.css
+++ b/packages/ui/src/components/toast/Toast.css
@@ -60,9 +60,10 @@
 .toast__text span {
   font-size: 12px;
   opacity: 0.8;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3; /* wrap up to 3 lines so error detail stays readable */
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .toast__dismiss {
@@ -110,5 +111,12 @@
   20% {
     transform: scale(1.35);
     opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .sbtl-loader path {
+    animation: none;
   }
 }

--- a/packages/ui/src/components/toast/Toast.css
+++ b/packages/ui/src/components/toast/Toast.css
@@ -1,0 +1,114 @@
+.toast-container {
+  position: fixed;
+  /* 97px = NowPlayingBar height — keep in sync with UpdateNotification.css */
+  bottom: 97px;
+  right: 24px;
+  /* z-index 9998 = just under UpdateNotification (9999) so the update chip stays on top */
+  z-index: 9998;
+  display: flex;
+  flex-direction: column-reverse; /* newest toast at the bottom of the stack */
+  gap: 10px;
+  pointer-events: none;
+}
+.toast-container .toast {
+  pointer-events: auto;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 240px;
+  max-width: 360px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: #e8e8ea;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.55);
+  animation: toastSlideIn 0.25s ease-out;
+}
+
+.toast__icon {
+  display: flex;
+  flex: 0 0 auto;
+}
+.toast--success .toast__icon {
+  color: #4ade80;
+}
+.toast--error .toast__icon {
+  color: #f87171;
+}
+.toast--info .toast__icon {
+  color: #93c5fd;
+}
+.toast--progress .toast__icon {
+  color: #e8e8ea;
+}
+
+.toast__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.toast__text strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+.toast__text span {
+  font-size: 12px;
+  opacity: 0.8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.toast__dismiss {
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.5;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 2px;
+  flex: 0 0 auto;
+}
+.toast__dismiss:hover {
+  opacity: 1;
+}
+
+@keyframes toastSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* --- sbtl sequential-pop loader --- */
+.sbtl-loader path {
+  transform-box: fill-box; /* scale each letter about its own box, not the svg origin */
+  transform-origin: center;
+  animation: sbtl-pop 1.4s ease-in-out infinite;
+}
+/* 4 direct <path> children of SbtlMark's <svg> = the letters s, b, t, l */
+.sbtl-loader path:nth-of-type(1) { animation-delay: 0s; }
+.sbtl-loader path:nth-of-type(2) { animation-delay: 0.15s; }
+.sbtl-loader path:nth-of-type(3) { animation-delay: 0.3s; }
+.sbtl-loader path:nth-of-type(4) { animation-delay: 0.45s; }
+
+@keyframes sbtl-pop {
+  0%, 40%, 100% {
+    transform: scale(1);
+    opacity: 0.75;
+  }
+  20% {
+    transform: scale(1.35);
+    opacity: 1;
+  }
+}

--- a/packages/ui/src/components/toast/ToastContainer.tsx
+++ b/packages/ui/src/components/toast/ToastContainer.tsx
@@ -1,0 +1,15 @@
+import { useToasts } from '../../stores/toastStore';
+import { ToastItem } from './ToastItem';
+import './Toast.css';
+
+export function ToastContainer() {
+  const toasts = useToasts();
+  if (toasts.length === 0) return null;
+  return (
+    <div className="toast-container" role="status" aria-live="polite" aria-atomic="false">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/toast/ToastContainer.tsx
+++ b/packages/ui/src/components/toast/ToastContainer.tsx
@@ -1,12 +1,16 @@
 import { useToasts } from '../../stores/toastStore';
 import { ToastItem } from './ToastItem';
+import { UpdateNotification } from '../UpdateNotification';
 import './Toast.css';
 
 export function ToastContainer() {
   const toasts = useToasts();
-  if (toasts.length === 0) return null;
+  // Always rendered: the UpdateNotification (sticky update chip) self-nulls when inactive and
+  // anchors the bottom of the stack; transient toasts pile up above it. column-reverse in CSS
+  // puts the first DOM child (the chip) at the bottom.
   return (
     <div className="toast-container" role="status" aria-live="polite" aria-atomic="false">
+      <UpdateNotification />
       {toasts.map((t) => (
         <ToastItem key={t.id} toast={t} />
       ))}

--- a/packages/ui/src/components/toast/ToastItem.tsx
+++ b/packages/ui/src/components/toast/ToastItem.tsx
@@ -46,7 +46,7 @@ function ToastIcon({ kind }: { kind: Exclude<ToastKind, 'progress'> }) {
     );
   }
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
       <circle cx="12" cy="12" r="9" />
       <line x1="12" y1="11" x2="12" y2="16" />
       <line x1="12" y1="8" x2="12" y2="8" />

--- a/packages/ui/src/components/toast/ToastItem.tsx
+++ b/packages/ui/src/components/toast/ToastItem.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { useToastStore, type Toast, type ToastKind } from '../../stores/toastStore';
+import { SbtlLoader } from './SbtlLoader';
+
+export function ToastItem({ toast }: { toast: Toast }) {
+  const dismiss = useToastStore((s) => s.dismissToast);
+
+  // Arm an auto-dismiss timer for transient kinds. Deps include kind+duration so a
+  // progress→success flip re-runs this and arms the timer; progress stays sticky.
+  useEffect(() => {
+    if (toast.kind === 'progress' || !toast.duration) return;
+    const t = setTimeout(() => dismiss(toast.id), toast.duration);
+    return () => clearTimeout(t);
+  }, [toast.id, toast.kind, toast.duration, dismiss]);
+
+  return (
+    <div className={`toast toast--${toast.kind}`}>
+      <div className="toast__icon">
+        {toast.kind === 'progress' ? <SbtlLoader /> : <ToastIcon kind={toast.kind} />}
+      </div>
+      <div className="toast__text">
+        <strong>{toast.title}</strong>
+        {toast.message && <span>{toast.message}</span>}
+      </div>
+      <button className="toast__dismiss" onClick={() => dismiss(toast.id)} aria-label="Dismiss">
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function ToastIcon({ kind }: { kind: Exclude<ToastKind, 'progress'> }) {
+  if (kind === 'success') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    );
+  }
+  if (kind === 'error') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    );
+  }
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+      <circle cx="12" cy="12" r="9" />
+      <line x1="12" y1="11" x2="12" y2="16" />
+      <line x1="12" y1="8" x2="12" y2="8" />
+    </svg>
+  );
+}

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -53,6 +53,11 @@ export function markSourceDeleted(sourceId: string) {
   setTimeout(() => deletedSourceIds.delete(sourceId), 30000);
 }
 
+// Un-suppress a source whose deletion failed part-way (it still exists).
+export function unmarkSourceDeleted(sourceId: string) {
+  deletedSourceIds.delete(sourceId);
+}
+
 function isSourceDeleted(sourceId: string): boolean {
   return deletedSourceIds.has(sourceId);
 }

--- a/packages/ui/src/hooks/useToast.ts
+++ b/packages/ui/src/hooks/useToast.ts
@@ -1,0 +1,35 @@
+import { useToastStore, type Toast } from '../stores/toastStore';
+
+const DURATION = { success: 4000, info: 4000, error: 6000 } as const;
+
+/**
+ * Ergonomic toast helpers. Components call `const toast = useToast()` and fire
+ * `toast.error/success/info(...)`. `toast.progress(...)` returns handles to flip
+ * the SAME toast from progress → success/error in place (e.g. removing → removed).
+ *
+ * Non-component callers (deep effect catches) use `useToastStore.getState().addToast(...)`.
+ */
+export function useToast() {
+  const add = useToastStore((s) => s.addToast);
+  const update = useToastStore((s) => s.updateToast);
+
+  return {
+    error: (title: string, message?: string) =>
+      add({ kind: 'error', title, message, duration: DURATION.error }),
+    success: (title: string, message?: string) =>
+      add({ kind: 'success', title, message, duration: DURATION.success }),
+    info: (title: string, message?: string) =>
+      add({ kind: 'info', title, message, duration: DURATION.info }),
+    progress: (title: string, message?: string) => {
+      const id = add({ kind: 'progress', title, message }); // sticky (no duration)
+      return {
+        id,
+        succeed: (t?: string, m?: string) =>
+          update(id, { kind: 'success', title: t ?? title, message: m, duration: DURATION.success }),
+        fail: (t?: string, m?: string) =>
+          update(id, { kind: 'error', title: t ?? title, message: m, duration: DURATION.error }),
+        update: (patch: Partial<Omit<Toast, 'id'>>) => update(id, patch),
+      };
+    },
+  };
+}

--- a/packages/ui/src/hooks/useToast.ts
+++ b/packages/ui/src/hooks/useToast.ts
@@ -1,6 +1,6 @@
-import { useToastStore, type Toast } from '../stores/toastStore';
+import { useToastStore } from '../stores/toastStore';
 
-const DURATION = { success: 4000, info: 4000, error: 6000 } as const;
+const DURATION = { success: 4000, info: 4000, error: 8000 } as const;
 
 /**
  * Ergonomic toast helpers. Components call `const toast = useToast()` and fire
@@ -28,7 +28,6 @@ export function useToast() {
           update(id, { kind: 'success', title: t ?? title, message: m, duration: DURATION.success }),
         fail: (t?: string, m?: string) =>
           update(id, { kind: 'error', title: t ?? title, message: m, duration: DURATION.error }),
-        update: (patch: Partial<Omit<Toast, 'id'>>) => update(id, patch),
       };
     },
   };

--- a/packages/ui/src/stores/toastStore.test.ts
+++ b/packages/ui/src/stores/toastStore.test.ts
@@ -56,4 +56,19 @@ describe('toastStore', () => {
     expect(ts).toHaveLength(4);
     expect(ts.map((x) => x.title)).toEqual(['Removing…', 'B', 'C', 'D']); // oldest non-progress ('A') dropped
   });
+
+  it('updateToast on an unknown id is a no-op', () => {
+    const id = useToastStore.getState().addToast({ kind: 'info', title: 'X' });
+    useToastStore.getState().dismissToast(id);
+    useToastStore.getState().updateToast(id, { kind: 'success' }); // stale id — must not throw or re-add
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('keeps all toasts when every slot is progress (intentional over-cap)', () => {
+    ['P1', 'P2', 'P3', 'P4', 'P5'].forEach((title) =>
+      useToastStore.getState().addToast({ kind: 'progress', title })
+    );
+    expect(useToastStore.getState().toasts).toHaveLength(5);
+    expect(useToastStore.getState().toasts.every((t) => t.kind === 'progress')).toBe(true);
+  });
 });

--- a/packages/ui/src/stores/toastStore.test.ts
+++ b/packages/ui/src/stores/toastStore.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useToastStore } from './toastStore';
+
+const reset = () => useToastStore.setState({ toasts: [] });
+
+describe('toastStore', () => {
+  beforeEach(reset);
+
+  it('addToast appends and returns a unique id', () => {
+    const id1 = useToastStore.getState().addToast({ kind: 'info', title: 'A' });
+    const id2 = useToastStore.getState().addToast({ kind: 'info', title: 'B' });
+    expect(id1).not.toEqual(id2);
+    expect(useToastStore.getState().toasts.map((t) => t.title)).toEqual(['A', 'B']);
+    expect(useToastStore.getState().toasts[0].id).toEqual(id1);
+  });
+
+  it('updateToast patches by id', () => {
+    const id = useToastStore.getState().addToast({ kind: 'progress', title: 'Removing…' });
+    useToastStore.getState().updateToast(id, { kind: 'success', title: 'Removed', duration: 4000 });
+    const t = useToastStore.getState().toasts.find((x) => x.id === id)!;
+    expect(t.kind).toEqual('success');
+    expect(t.title).toEqual('Removed');
+    expect(t.duration).toEqual(4000);
+  });
+
+  it('dismissToast removes by id', () => {
+    const id = useToastStore.getState().addToast({ kind: 'error', title: 'X' });
+    useToastStore.getState().dismissToast(id);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('caps the stack at 4, dropping the oldest', () => {
+    const ids = ['A', 'B', 'C', 'D', 'E'].map((title) =>
+      useToastStore.getState().addToast({ kind: 'info', title })
+    );
+    const titles = useToastStore.getState().toasts.map((t) => t.title);
+    expect(titles).toEqual(['B', 'C', 'D', 'E']); // 'A' (oldest) dropped
+    expect(useToastStore.getState().toasts.find((t) => t.id === ids[0])).toBeUndefined();
+  });
+
+  it('progress → succeed flips the same toast to success in place', () => {
+    const id = useToastStore.getState().addToast({ kind: 'progress', title: 'Removing…' });
+    useToastStore.getState().updateToast(id, { kind: 'success', title: 'Removed', duration: 4000 });
+    const ts = useToastStore.getState().toasts;
+    expect(ts).toHaveLength(1);
+    expect(ts[0].kind).toEqual('success');
+  });
+
+  it('does not evict an in-flight progress toast when capping', () => {
+    const pid = useToastStore.getState().addToast({ kind: 'progress', title: 'Removing…' });
+    ['A', 'B', 'C', 'D'].forEach((title) =>
+      useToastStore.getState().addToast({ kind: 'info', title })
+    );
+    const ts = useToastStore.getState().toasts;
+    expect(ts.find((x) => x.id === pid)).toBeDefined();   // progress survives
+    expect(ts).toHaveLength(4);
+    expect(ts.map((x) => x.title)).toEqual(['Removing…', 'B', 'C', 'D']); // oldest non-progress ('A') dropped
+  });
+});

--- a/packages/ui/src/stores/toastStore.ts
+++ b/packages/ui/src/stores/toastStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+export type ToastKind = 'progress' | 'success' | 'error' | 'info';
+
+export interface Toast {
+  id: string;
+  kind: ToastKind;
+  title: string;
+  message?: string;
+  duration?: number; // ms to auto-dismiss; undefined = sticky (progress)
+}
+
+const MAX_TOASTS = 4;
+let counter = 0;
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (t: Omit<Toast, 'id'>) => string;
+  updateToast: (id: string, patch: Partial<Omit<Toast, 'id'>>) => void;
+  dismissToast: (id: string) => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  addToast: (t) => {
+    const id = String(++counter);
+    set((s) => {
+      const next = [...s.toasts, { ...t, id }];
+      if (next.length <= MAX_TOASTS) return { toasts: next };
+      // Over cap: drop the oldest NON-progress toast so an in-flight progress
+      // toast is never orphaned (its later succeed()/fail() must still land).
+      const dropIdx = next.findIndex((x) => x.kind !== 'progress');
+      if (dropIdx === -1) return { toasts: next }; // all progress (rare) — keep them
+      return { toasts: [...next.slice(0, dropIdx), ...next.slice(dropIdx + 1)] };
+    });
+    return id;
+  },
+  updateToast: (id, patch) =>
+    set((s) => ({ toasts: s.toasts.map((x) => (x.id === id ? { ...x, ...patch } : x)) })),
+  dismissToast: (id) =>
+    set((s) => ({ toasts: s.toasts.filter((x) => x.id !== id) })),
+}));
+
+export const useToasts = () => useToastStore((s) => s.toasts);


### PR DESCRIPTION
## Summary

0.8.0 polish bundle (feature #2 of 2). A small reusable toast system plus the branded "removing account" progress toast and a curated set of error/success toasts.

- **Toast system** — dedicated Zustand `toastStore` (`add`/`update`/`dismiss`; stack cap of 4 that **never evicts an in-flight `progress` toast**), a `useToast()` hook (`error`/`success`/`info`/`progress`, where `progress()` flips the same toast to success/error **in place**), and `ToastContainer`/`ToastItem`/`SbtlLoader` components. Bottom-right stack, reuses the `UpdateNotification` slide-in.
- **sbtl loader** — the in-progress spinner is the bare "sbtl" letterforms (`SbtlMark`'s 4 paths) doing a staggered **sequential pop** (each letter scales up and settles, s→b→t→l, looping).
- **Wiring** — remove-source progress→result (#71), add-source **success** toast, and **initial-sync** failure error toast (#11, partial #22). Add-source *errors* stay inline in the form; **settings-save + manual-sync toasts are deferred** (fast-follow via the same hook).

## Testing

- ✅ 6 new `toastStore` unit tests (TDD): add/return-id, update-by-id, dismiss, stack-cap, progress→succeed, **progress-not-evicted**.
- ✅ `pnpm --filter @sbtltv/ui test` — **114/114** pass (108 + 6).
- ✅ `pnpm -r typecheck` clean.
- ⏳ Device-verify (Windows batch): remove an account → sequential-pop sbtl loader "Removing…" → flips to "Removed"; force a sync failure → "Sync failed" error toast; add a source → "Added \<name\>"; toasts stack bottom-right, auto-dismiss, coexist with the update chip.

## Review fixes folded in (4-agent plan pre-review)

stack-cap protects in-flight progress toasts · `progress→succeed` + protection unit tests · full `handleDelete` shown (the `!window.storage` guard is preserved) · `ToastContainer` uses the `useToasts` selector · `role="status" aria-live="polite"` on the container · coupling comments on the `bottom:97px`/z-index magic numbers · corrected the `SbtlLoader` viewBox comment.

---

9 files (7 new + App.tsx + SourcesTab.tsx). Spec/plan: `thoughts/shared/{specs,plans}/2026-06-01-toasts*` (local).
