### PR TITLE
feat: provider sort order for live TV categories (#48, live half of #60)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,6 +44,7 @@ export interface Category {
   category_name: string;
   source_id: string;
   parent_id?: number;     // For hierarchical categories (rare)
+  position?: number;      // Provider arrival index (0-based); captured at sync, used by Provider sort
 }
 
 export interface Channel {

--- a/packages/electron/src/storage.ts
+++ b/packages/electron/src/storage.ts
@@ -35,6 +35,7 @@ interface AppSettings {
   allowLanSources?: boolean;       // Allow requests to LAN IPs (SSRF protection bypass)
   debugLoggingEnabled?: boolean;   // Write verbose logs to file for debugging
   channelSortOrder?: 'alphabetical' | 'number';  // Channel list ordering (default: alphabetical)
+  categorySortOrder?: 'alphabetical' | 'provider';  // Live category strip ordering (default: alphabetical)
   autoUpdateEnabled?: boolean;  // Auto-check for updates on launch (default true)
   categoryBarWidth?: number;    // Category strip content width in px (default 160)
   guideOpacity?: number;        // Background opacity for EPG/category/title bar (default 0.95)
@@ -58,6 +59,7 @@ interface StoredSettings {
   allowLanSources?: boolean;        // Allow requests to LAN IPs
   debugLoggingEnabled?: boolean;    // Write verbose logs to file
   channelSortOrder?: 'alphabetical' | 'number';  // Channel list ordering
+  categorySortOrder?: 'alphabetical' | 'provider';  // Live category strip ordering
   autoUpdateEnabled?: boolean;  // Auto-check for updates on launch
   categoryBarWidth?: number;    // Category strip content width in px
   guideOpacity?: number;        // Background opacity for EPG/category/title bar
@@ -203,6 +205,7 @@ export function getSettings(): AppSettings {
   result.allowLanSources = stored.allowLanSources ?? false;
   result.debugLoggingEnabled = stored.debugLoggingEnabled ?? false;
   result.channelSortOrder = stored.channelSortOrder ?? 'alphabetical';
+  result.categorySortOrder = stored.categorySortOrder ?? 'alphabetical';
   result.autoUpdateEnabled = stored.autoUpdateEnabled ?? true;
   result.categoryBarWidth = stored.categoryBarWidth ?? 160;
   result.guideOpacity = stored.guideOpacity ?? 0.95;
@@ -243,6 +246,9 @@ export function updateSettings(settings: Partial<AppSettings>): void {
   }
   if (settings.channelSortOrder !== undefined) {
     updated.channelSortOrder = settings.channelSortOrder;
+  }
+  if (settings.categorySortOrder !== undefined) {
+    updated.categorySortOrder = settings.categorySortOrder;
   }
   if (settings.autoUpdateEnabled !== undefined) {
     updated.autoUpdateEnabled = settings.autoUpdateEnabled;

--- a/packages/ui/src/components/Settings.css
+++ b/packages/ui/src/components/Settings.css
@@ -783,6 +783,12 @@
   margin: 8px 0 0 0;
 }
 
+/* Breathing room when a control directly follows an explanatory hint
+   (e.g. the Category Order control under the Channel Number hint). */
+.epg-tab-scroll .form-hint + .form-group.inline {
+  margin-top: 16px;
+}
+
 .form-hint a {
   color: #00d4ff;
   text-decoration: none;

--- a/packages/ui/src/components/Settings.tsx
+++ b/packages/ui/src/components/Settings.tsx
@@ -52,6 +52,7 @@ export function Settings({ onClose }: SettingsProps) {
 
   // Channel display state
   const [channelSortOrder, setChannelSortOrder] = useState<'alphabetical' | 'number'>('alphabetical');
+  const [categorySortOrder, setCategorySortOrder] = useState<'alphabetical' | 'provider'>('alphabetical');
 
   // Guide appearance state
   const [categoryBarWidth, setCategoryBarWidth] = useState(160);
@@ -130,6 +131,7 @@ export function Settings({ onClose }: SettingsProps) {
 
     // Load channel display settings
     setChannelSortOrder(s.channelSortOrder ?? 'alphabetical');
+    setCategorySortOrder(s.categorySortOrder ?? 'alphabetical');
 
     // Load auto-update setting (default ON)
     setAutoUpdateEnabled(s.autoUpdateEnabled ?? true);
@@ -204,6 +206,8 @@ export function Settings({ onClose }: SettingsProps) {
           <EpgTab
             channelSortOrder={channelSortOrder}
             onChannelSortOrderChange={setChannelSortOrder}
+            categorySortOrder={categorySortOrder}
+            onCategorySortOrderChange={setCategorySortOrder}
             categoryBarWidth={categoryBarWidth}
             guideOpacity={guideOpacity}
             onCategoryBarWidthChange={setCategoryBarWidth}

--- a/packages/ui/src/components/settings/EpgTab.tsx
+++ b/packages/ui/src/components/settings/EpgTab.tsx
@@ -1,8 +1,13 @@
 import { useUpdateSettings } from '../../stores/uiStore';
+import { db } from '../../db';
+import { syncAllSources } from '../../db/sync';
+import { useToast } from '../../hooks/useToast';
 
 interface EpgTabProps {
   channelSortOrder: 'alphabetical' | 'number';
   onChannelSortOrderChange: (order: 'alphabetical' | 'number') => void;
+  categorySortOrder: 'alphabetical' | 'provider';
+  onCategorySortOrderChange: (order: 'alphabetical' | 'provider') => void;
   categoryBarWidth: number;
   guideOpacity: number;
   onCategoryBarWidthChange: (width: number) => void;
@@ -14,6 +19,8 @@ interface EpgTabProps {
 export function EpgTab({
   channelSortOrder,
   onChannelSortOrderChange,
+  categorySortOrder,
+  onCategorySortOrderChange,
   categoryBarWidth,
   guideOpacity,
   onCategoryBarWidthChange,
@@ -22,12 +29,35 @@ export function EpgTab({
   onSportsMatchupChange,
 }: EpgTabProps) {
   const updateSettings = useUpdateSettings();
+  const toast = useToast();
 
   async function handleSortOrderChange(order: 'alphabetical' | 'number') {
     onChannelSortOrderChange(order);
     updateSettings({ channelSortOrder: order });
     if (!window.storage) return;
     await window.storage.updateSettings({ channelSortOrder: order });
+  }
+
+  async function handleCategorySortOrderChange(order: 'alphabetical' | 'provider') {
+    onCategorySortOrderChange(order);
+    updateSettings({ categorySortOrder: order });
+    if (window.storage) {
+      await window.storage.updateSettings({ categorySortOrder: order });
+    }
+
+    // Provider order needs per-category `position`; backfill via resync if absent.
+    if (order === 'provider') {
+      const ready = (await db.categories.where('position').aboveOrEqual(0).count()) > 0;
+      if (!ready) {
+        const t = toast.progress('Preparing provider order…', 'Re-syncing your channels');
+        try {
+          await syncAllSources();
+          t.succeed('Provider order ready');
+        } catch {
+          t.fail('Could not prepare provider order', 'Try syncing from the Sources tab');
+        }
+      }
+    }
   }
 
   async function handleWidthChange(width: number) {
@@ -77,6 +107,23 @@ export function EpgTab({
         <p className="form-hint">
           "Channel Number" uses the order from your provider (Xtream num or M3U tvg-chno).
           Channels without a number will appear at the end, sorted alphabetically.
+        </p>
+
+        <div className="form-group inline">
+          <label>Category Order</label>
+          <select
+            value={categorySortOrder}
+            onChange={(e) => handleCategorySortOrderChange(e.target.value as 'alphabetical' | 'provider')}
+          >
+            <option value="alphabetical">Alphabetical (A-Z)</option>
+            <option value="provider">Provider Order</option>
+          </select>
+        </div>
+
+        <p className="form-hint">
+          "Provider Order" keeps the category arrangement from your source — the
+          folders your provider curated at the top stay on top. With multiple sources,
+          your highest-priority source defines the layout.
         </p>
       </div>
 

--- a/packages/ui/src/components/settings/EpgTab.tsx
+++ b/packages/ui/src/components/settings/EpgTab.tsx
@@ -139,7 +139,7 @@ export function EpgTab({
         </div>
 
         <p className="form-hint">
-          "Provider Order" keeps the category arrangement from your source — the
+          "Provider Order" keeps the category arrangement from your source, so the
           folders your provider curated at the top stay on top. With multiple sources,
           your highest-priority source defines the layout.
         </p>

--- a/packages/ui/src/components/settings/EpgTab.tsx
+++ b/packages/ui/src/components/settings/EpgTab.tsx
@@ -2,6 +2,7 @@ import { useUpdateSettings } from '../../stores/uiStore';
 import { db } from '../../db';
 import { syncAllSources } from '../../db/sync';
 import { useToast } from '../../hooks/useToast';
+import { debugLog } from '../../utils/debugLog';
 
 interface EpgTabProps {
   channelSortOrder: 'alphabetical' | 'number';
@@ -44,18 +45,35 @@ export function EpgTab({
     if (window.storage) {
       await window.storage.updateSettings({ categorySortOrder: order });
     }
+    if (order !== 'provider') return;
 
     // Provider order needs per-category `position`; backfill via resync if absent.
-    if (order === 'provider') {
+    // syncAllSources() only throws on infra errors — per-source failures come back
+    // in the result map, so inspect it rather than trusting a non-throw as success.
+    let progress: ReturnType<typeof toast.progress> | undefined;
+    try {
       const ready = (await db.categories.where('position').aboveOrEqual(0).count()) > 0;
-      if (!ready) {
-        const t = toast.progress('Preparing provider order…', 'Re-syncing your channels');
-        try {
-          await syncAllSources();
-          t.succeed('Provider order ready');
-        } catch {
-          t.fail('Could not prepare provider order', 'Try syncing from the Sources tab');
-        }
+      if (ready) return;
+
+      progress = toast.progress('Preparing provider order…', 'Re-syncing your channels');
+      const results = await syncAllSources();
+      const failed = [...results.values()].filter((r) => !r.success).length;
+
+      if (results.size === 0) {
+        progress.fail('No channels to sync', 'Add a source in the Sources tab first');
+      } else if (failed === results.size) {
+        progress.fail('Could not prepare provider order', 'Try syncing from the Sources tab');
+      } else if (failed > 0) {
+        progress.succeed('Provider order ready', 'Some sources failed — check the Sources tab');
+      } else {
+        progress.succeed('Provider order ready');
+      }
+    } catch (err) {
+      debugLog(`[category-sort] provider-order resync failed: ${err instanceof Error ? err.message : String(err)}`, 'sync');
+      if (progress) {
+        progress.fail('Could not prepare provider order', 'Try syncing from the Sources tab');
+      } else {
+        toast.error('Could not prepare provider order', 'Try again or restart the app');
       }
     }
   }

--- a/packages/ui/src/db/categoryPosition.test.ts
+++ b/packages/ui/src/db/categoryPosition.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import type { Category } from '@sbtltv/core';
+import { assignCategoryPositions } from './categoryPosition';
+
+function cat(id: string): Category {
+  return { category_id: id, category_name: id, source_id: 's1' };
+}
+
+describe('assignCategoryPositions', () => {
+  it('assigns 0-based position in array order', () => {
+    const out = assignCategoryPositions([cat('a'), cat('b'), cat('c')]);
+    expect(out.map((c) => c.position)).toEqual([0, 1, 2]);
+  });
+
+  it('does not mutate the input array items', () => {
+    const input = [cat('a')];
+    const out = assignCategoryPositions(input);
+    expect(input[0].position).toBeUndefined();
+    expect(out[0].position).toBe(0);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(assignCategoryPositions([])).toEqual([]);
+  });
+});

--- a/packages/ui/src/db/categoryPosition.ts
+++ b/packages/ui/src/db/categoryPosition.ts
@@ -1,0 +1,11 @@
+import type { Category } from '@sbtltv/core';
+
+/**
+ * Stamp each category with its provider arrival index (0-based).
+ * Both adapters deliver categories in provider order — M3U by first-appearance
+ * of group-title, Xtream by API array order — so the index IS the provider order.
+ * Returns new objects; does not mutate inputs.
+ */
+export function assignCategoryPositions<T extends Category>(categories: T[]): T[] {
+  return categories.map((c, i) => ({ ...c, position: i }));
+}

--- a/packages/ui/src/db/index.ts
+++ b/packages/ui/src/db/index.ts
@@ -296,6 +296,16 @@ class SbtltvDatabase extends Dexie {
     this.version(13).stores({
       watchProgress: 'id, type, tmdb_id, stream_id, series_tmdb_id, series_stream_id, updated_at, [type+completed]',
     });
+
+    // Index `position` on categories so live categories can be ordered by the
+    // provider's original arrangement (Provider sort). Additive index ONLY — Dexie
+    // builds it in place, existing records preserved (position stays undefined until a
+    // source is next synced). No upgrade callback / no forced resync: backfill for
+    // opt-in users happens via auto-resync-on-enable in the settings UI. The index
+    // powers the readiness check `db.categories.where('position').aboveOrEqual(0)`.
+    this.version(14).stores({
+      categories: 'category_id, source_id, category_name, position',
+    });
   }
 }
 

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -1,5 +1,6 @@
 import { type Table } from 'dexie';
 import { db, clearSourceData, clearVodData, type SourceMeta, type StoredProgram, type StoredMovie, type StoredSeries, type StoredEpisode, type VodCategory, type EpgMapping } from './index';
+import { assignCategoryPositions } from './categoryPosition';
 import { fetchAndParseM3U, XtreamClient, type XmltvProgram, type XmltvChannel } from '@sbtltv/local-adapter';
 import { matchChannelsToEpg } from '../services/epg-matcher';
 import type { Source, Channel, Category, Movie, Series } from '@sbtltv/core';
@@ -539,7 +540,7 @@ export async function syncSource(source: Source): Promise<SyncResult> {
         await db.channels.bulkPut(channels);
       }
       if (categories.length > 0) {
-        await db.categories.bulkPut(categories);
+        await db.categories.bulkPut(assignCategoryPositions(categories));
       }
 
       // Store sync metadata

--- a/packages/ui/src/hooks/categorySort.test.ts
+++ b/packages/ui/src/hooks/categorySort.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { sortCategoryGroups, type CategorySortable } from './categorySort';
+
+function g(name: string, primaryPriority: number, primaryPosition: number): CategorySortable {
+  return { name, primaryPriority, primaryPosition };
+}
+
+describe('sortCategoryGroups', () => {
+  it('alphabetical mode sorts by name', () => {
+    // same-case inputs to avoid locale-dependent case ordering
+    const out = sortCategoryGroups(
+      [g('Sports', 0, 5), g('Movies', 0, 0), g('News', 0, 2)],
+      'alphabetical',
+    );
+    expect(out.map((x) => x.name)).toEqual(['Movies', 'News', 'Sports']);
+  });
+
+  it('provider mode, single source: orders by position', () => {
+    const out = sortCategoryGroups(
+      [g('Sports', 0, 5), g('Movies', 0, 0), g('UK', 0, 1)],
+      'provider',
+    );
+    expect(out.map((x) => x.name)).toEqual(['Movies', 'UK', 'Sports']);
+  });
+
+  it('provider mode, multi-source: highest-priority source first, then position', () => {
+    // Source priority 0 beats 1; within a source, position decides.
+    const out = sortCategoryGroups(
+      [g('B-from-src2', 1, 0), g('A-from-src1', 0, 9), g('C-from-src1', 0, 0)],
+      'provider',
+    );
+    expect(out.map((x) => x.name)).toEqual(['C-from-src1', 'A-from-src1', 'B-from-src2']);
+  });
+
+  it('provider mode: defensive — unknown priority (999) sorts after known sources', () => {
+    // 999 = source absent from liveSourceOrder (a dead branch in practice, since
+    // categories are filtered to enabled sources, but the comparator must be safe).
+    const out = sortCategoryGroups(
+      [g('Unknown', 999, 0), g('Known', 0, 5)],
+      'provider',
+    );
+    expect(out.map((x) => x.name)).toEqual(['Known', 'Unknown']);
+  });
+
+  it('provider mode: missing position (Infinity) sorts last, alpha among ties', () => {
+    const out = sortCategoryGroups(
+      [g('Zeta', 0, Number.POSITIVE_INFINITY), g('Alpha', 0, Number.POSITIVE_INFINITY), g('Real', 0, 0)],
+      'provider',
+    );
+    expect(out.map((x) => x.name)).toEqual(['Real', 'Alpha', 'Zeta']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [g('B', 0, 1), g('A', 0, 0)];
+    sortCategoryGroups(input, 'provider');
+    expect(input.map((x) => x.name)).toEqual(['B', 'A']);
+  });
+});

--- a/packages/ui/src/hooks/categorySort.test.ts
+++ b/packages/ui/src/hooks/categorySort.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sortCategoryGroups, type CategorySortable } from './categorySort';
+import { sortCategoryGroups, resolveGroupPrimary, type CategorySortable } from './categorySort';
 
 function g(name: string, primaryPriority: number, primaryPosition: number): CategorySortable {
   return { name, primaryPriority, primaryPosition };
@@ -54,5 +54,43 @@ describe('sortCategoryGroups', () => {
     const input = [g('B', 0, 1), g('A', 0, 0)];
     sortCategoryGroups(input, 'provider');
     expect(input.map((x) => x.name)).toEqual(['B', 'A']);
+  });
+
+  it('returns an empty array in both modes', () => {
+    expect(sortCategoryGroups([], 'alphabetical')).toEqual([]);
+    expect(sortCategoryGroups([], 'provider')).toEqual([]);
+  });
+
+  it('provider mode: same priority and finite position falls back to alpha', () => {
+    const out = sortCategoryGroups(
+      [g('Zebra', 0, 5), g('Apple', 0, 5), g('Mango', 0, 5)],
+      'provider',
+    );
+    expect(out.map((x) => x.name)).toEqual(['Apple', 'Mango', 'Zebra']);
+  });
+});
+
+describe('resolveGroupPrimary', () => {
+  const order = new Map([['s1', 0], ['s2', 1]]);
+
+  it('single source: returns that source priority + position', () => {
+    const sources = [{ sourceId: 's2', position: 4 }];
+    expect(resolveGroupPrimary(sources, order)).toEqual({ primaryPriority: 1, primaryPosition: 4 });
+  });
+
+  it('multi source: sorts sources by priority and reports the top one', () => {
+    const sources = [
+      { sourceId: 's2', position: 0 },
+      { sourceId: 's1', position: 7 },
+    ];
+    const primary = resolveGroupPrimary(sources, order);
+    // sources reordered in place: highest-priority (s1) first
+    expect(sources.map((s) => s.sourceId)).toEqual(['s1', 's2']);
+    expect(primary).toEqual({ primaryPriority: 0, primaryPosition: 7 });
+  });
+
+  it('unknown source (absent from order) gets priority 999', () => {
+    const sources = [{ sourceId: 'ghost', position: 2 }];
+    expect(resolveGroupPrimary(sources, order)).toEqual({ primaryPriority: 999, primaryPosition: 2 });
   });
 });

--- a/packages/ui/src/hooks/categorySort.ts
+++ b/packages/ui/src/hooks/categorySort.ts
@@ -5,6 +5,30 @@ export interface CategorySortable {
   primaryPosition: number;  // provider position within that source (Infinity if unknown)
 }
 
+const UNKNOWN_SOURCE_PRIORITY = 999;
+
+/**
+ * Order a group's per-source entries by live-source priority (lower index in
+ * `orderIndex` = higher priority; sources absent from the order sink to the end),
+ * then report the resulting primary source's priority + position. Sorts `sources`
+ * in place (the UI renders sub-items in this order) and returns the primary's keys.
+ */
+export function resolveGroupPrimary<T extends { sourceId: string; position: number }>(
+  sources: T[],
+  orderIndex: Map<string, number>,
+): { primaryPriority: number; primaryPosition: number } {
+  sources.sort(
+    (a, b) =>
+      (orderIndex.get(a.sourceId) ?? UNKNOWN_SOURCE_PRIORITY) -
+      (orderIndex.get(b.sourceId) ?? UNKNOWN_SOURCE_PRIORITY),
+  );
+  const primary = sources[0];
+  return {
+    primaryPriority: orderIndex.get(primary.sourceId) ?? UNKNOWN_SOURCE_PRIORITY,
+    primaryPosition: primary.position,
+  };
+}
+
 /**
  * Order category groups for the live strip.
  * - 'alphabetical': by display name (current behavior).

--- a/packages/ui/src/hooks/categorySort.ts
+++ b/packages/ui/src/hooks/categorySort.ts
@@ -1,0 +1,29 @@
+/** Minimal shape the comparator needs — `GroupedCategory` satisfies this. */
+export interface CategorySortable {
+  name: string;
+  primaryPriority: number;  // source priority of the group's primary source (lower = higher priority)
+  primaryPosition: number;  // provider position within that source (Infinity if unknown)
+}
+
+/**
+ * Order category groups for the live strip.
+ * - 'alphabetical': by display name (current behavior).
+ * - 'provider': by (primaryPriority, primaryPosition), then name as a stable
+ *   tiebreak — i.e. highest-priority source first, then that source's order;
+ *   groups with no known position fall to the end, alphabetised among themselves.
+ * Pure: returns a new array, never mutates the input.
+ */
+export function sortCategoryGroups<T extends CategorySortable>(
+  groups: T[],
+  mode: 'alphabetical' | 'provider',
+): T[] {
+  const copy = [...groups];
+  if (mode === 'alphabetical') {
+    return copy.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return copy.sort((a, b) => {
+    if (a.primaryPriority !== b.primaryPriority) return a.primaryPriority - b.primaryPriority;
+    if (a.primaryPosition !== b.primaryPosition) return a.primaryPosition - b.primaryPosition;
+    return a.name.localeCompare(b.name);
+  });
+}

--- a/packages/ui/src/hooks/useChannels.ts
+++ b/packages/ui/src/hooks/useChannels.ts
@@ -3,6 +3,8 @@ import { db, getLastCategory, setLastCategory } from '../db';
 import type { StoredChannel, StoredCategory, SourceMeta, StoredProgram } from '../db';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useEnabledSourceIds, useLiveSourceOrder, useSourceMap } from './useSourceFiltering';
+import { sortCategoryGroups } from './categorySort';
+import { useCategorySortOrder } from '../stores/uiStore';
 
 // Hook to get all categories across enabled sources
 export function useCategories() {
@@ -280,8 +282,11 @@ export interface GroupedCategory {
     sourceName: string;
     categoryId: string;
     channelCount: number;
+    position: number;        // provider position of this category within its source (Infinity if unknown)
   }[];
   totalCount: number;
+  primaryPriority: number;   // source priority of sources[0] (lower = higher priority)
+  primaryPosition: number;   // position of sources[0]'s category (Infinity if unknown)
 }
 
 // Hook to get categories grouped by name for adaptive display.
@@ -291,6 +296,7 @@ export function useGroupedCategories(): GroupedCategory[] {
   const categoriesWithCounts = useCategoriesWithCounts();
   const liveSourceOrder = useLiveSourceOrder();
   const sourceMap = useSourceMap();
+  const categorySortOrder = useCategorySortOrder();
 
   return useMemo(() => {
     // Group categories by normalized name
@@ -310,6 +316,7 @@ export function useGroupedCategories(): GroupedCategory[] {
         sourceName,
         categoryId: cat.category_id,
         channelCount: cat.channelCount,
+        position: cat.position ?? Number.POSITIVE_INFINITY,
       };
 
       if (existing) {
@@ -320,6 +327,8 @@ export function useGroupedCategories(): GroupedCategory[] {
           name: normalizedName,
           sources: [entry],
           totalCount: cat.channelCount,
+          primaryPriority: 999,
+          primaryPosition: Number.POSITIVE_INFINITY,
         });
       }
     }
@@ -334,11 +343,13 @@ export function useGroupedCategories(): GroupedCategory[] {
           return aIdx - bIdx;
         });
       }
+      // Primary = highest-priority source (sources[0] after the sort above)
+      const primary = group.sources[0];
+      group.primaryPriority = orderIndex.get(primary.sourceId) ?? 999;
+      group.primaryPosition = primary.position;
     }
 
-    // Sort groups alphabetically by name
-    return Array.from(grouped.values()).sort((a, b) =>
-      a.name.localeCompare(b.name)
-    );
-  }, [categoriesWithCounts, liveSourceOrder, sourceMap]);
+    // Sort groups by the active order (alphabetical default, or provider order)
+    return sortCategoryGroups(Array.from(grouped.values()), categorySortOrder);
+  }, [categoriesWithCounts, liveSourceOrder, sourceMap, categorySortOrder]);
 }

--- a/packages/ui/src/hooks/useChannels.ts
+++ b/packages/ui/src/hooks/useChannels.ts
@@ -3,7 +3,7 @@ import { db, getLastCategory, setLastCategory } from '../db';
 import type { StoredChannel, StoredCategory, SourceMeta, StoredProgram } from '../db';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useEnabledSourceIds, useLiveSourceOrder, useSourceMap } from './useSourceFiltering';
-import { sortCategoryGroups } from './categorySort';
+import { sortCategoryGroups, resolveGroupPrimary } from './categorySort';
 import { useCategorySortOrder } from '../stores/uiStore';
 
 // Hook to get all categories across enabled sources
@@ -333,20 +333,12 @@ export function useGroupedCategories(): GroupedCategory[] {
       }
     }
 
-    // Sort sub-items by live source preference order
+    // Order each group's sub-items by live source priority + resolve its primary
     const orderIndex = new Map(liveSourceOrder.map((id, i) => [id, i]));
     for (const group of grouped.values()) {
-      if (group.sources.length > 1) {
-        group.sources.sort((a, b) => {
-          const aIdx = orderIndex.get(a.sourceId) ?? 999;
-          const bIdx = orderIndex.get(b.sourceId) ?? 999;
-          return aIdx - bIdx;
-        });
-      }
-      // Primary = highest-priority source (sources[0] after the sort above)
-      const primary = group.sources[0];
-      group.primaryPriority = orderIndex.get(primary.sourceId) ?? 999;
-      group.primaryPosition = primary.position;
+      const { primaryPriority, primaryPosition } = resolveGroupPrimary(group.sources, orderIndex);
+      group.primaryPriority = primaryPriority;
+      group.primaryPosition = primaryPosition;
     }
 
     // Sort groups by the active order (alphabetical default, or provider order)

--- a/packages/ui/src/stores/uiStore.ts
+++ b/packages/ui/src/stores/uiStore.ts
@@ -94,6 +94,7 @@ interface UIState {
 const DEFAULT_SETTINGS: AppSettings = {
   theme: 'dark',
   channelSortOrder: 'alphabetical',
+  categorySortOrder: 'alphabetical',
   categoryBarWidth: 160,
   guideOpacity: 0.95,
   vodRefreshHours: 24,
@@ -220,6 +221,7 @@ export const useSetCacheClearing = () => useUIStore((s) => s.setCacheClearing);
 
 // Settings selectors (read from settings object, with defaults)
 export const useChannelSortOrder = () => useUIStore((s) => s.settings.channelSortOrder ?? 'alphabetical');
+export const useCategorySortOrder = () => useUIStore((s) => s.settings.categorySortOrder ?? 'alphabetical');
 export const useCategoryBarWidth = () => useUIStore((s) => s.settings.categoryBarWidth ?? 160);
 export const useGuideOpacity = () => useUIStore((s) => s.settings.guideOpacity ?? 0.95);
 export const useTmdbApiKey = () => useUIStore((s) => s.settings.tmdbApiKey ?? null);

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -68,6 +68,7 @@ export interface AppSettings {
   allowLanSources?: boolean;       // Allow requests to LAN IPs (SSRF bypass)
   debugLoggingEnabled?: boolean;   // Write verbose logs to file for debugging
   channelSortOrder?: 'alphabetical' | 'number';  // Channel list ordering
+  categorySortOrder?: 'alphabetical' | 'provider';  // Live category strip ordering (default: alphabetical)
   autoUpdateEnabled?: boolean;  // Auto-check for updates on launch (default true)
   categoryBarWidth?: number;    // Category strip content width in px (default 160)
   guideOpacity?: number;        // Background opacity for EPG/category/title bar (default 0.95)


### PR DESCRIPTION
## What

Adds a **Category Order: Alphabetical | Provider** setting for Live TV. In **Provider** mode, the live category strip follows the provider's original arrangement (Xtream `get_live_categories` order / M3U `group-title` first-appearance) instead of forced-alphabetical. Default stays **Alphabetical (opt-in)** — no existing layout changes on update.

Closes #48. Satisfies the live-TV portion of #60.

**Out of scope (by product decision):** VOD categories/items stay alphabetical; live *channels* already have provider order via the existing `channelSortOrder` (`channel_num`) setting.

## How

- **`position` field** captured on every category sync (`assignCategoryPositions`, source-agnostic — both adapters already deliver provider order) + **Dexie v14** additive `position` index (no forced resync; same pattern as v7/v13).
- **`categorySortOrder`** setting mirrors `channelSortOrder` — persisted through the electron-store allowlist (`getSettings`/`updateSettings`), hydrated via the normal spread.
- **Pure `sortCategoryGroups` comparator** (TDD): provider mode orders groups by `(primaryPriority, primaryPosition)` → "highest-priority source first, then that source's position." Wired into `useGroupedCategories`.
- **Auto-resync-on-enable:** switching to Provider when categories lack `position` triggers `syncAllSources()` behind a progress toast; the strip re-sorts reactively when data lands. Replaces a forced launch resync — opt-in users only pay the cost.

## Design decisions

- Default Alphabetical (opt-in) — never reorders a layout on update.
- Multi-source tiebreak = highest-priority source first, then position (reuses existing `liveSourceOrder`).
- Additive v14 index, never destructive.

## Test plan

- ✅ `pnpm -r typecheck` clean (5 projects)
- ✅ `pnpm --filter @sbtltv/ui test` — 125 pass (116 existing + 9 new: 3 `assignCategoryPositions`, 6 `sortCategoryGroups`)
- ⏳ Device (Mac + Windows via build-test.yml): fresh-sync alphabetical unchanged; enable Provider on a pre-`position` install → "Preparing provider order…" toast → strip reorders; toggle persists across restart; multi-source order; switch back to A-Z.

## Notes

Spec + plan went through a 4-agent pre-review; two "critical" findings (preload type break, cross-source `category_id` collision) were verified as false alarms against source (both `AppSettings` interfaces are independent; category IDs are source-namespaced). `thoughts/` is gitignored so the spec/plan aren't in this diff.