### PR TITLE
Release 0.8.1 - Windows fullscreen fix (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2026-06-08
+
+### Fixed
+- **Windows fullscreen** - f / F11 / the player button now cover the whole screen (taskbar included) and exit cleanly via Esc / f / F11 / the title-bar control. Previously they only maximized the window, leaving the taskbar visible (#76)
+
 ## [0.8.0] - 2026-06-03
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,11 @@
-# sbtlTV 0.8.0
+# sbtlTV 0.8.1
 
-This release is dedicated to [jesmannstl](https://github.com/jesmannstl) of the Dispatcharr community - an EPG craftsman whose carefully curated guides were invaluable to sbtlTV's development and testing. So much of the EPG and guide work in recent releases stands on the shoulders of his. Rest easy.
+A small fix-up release for Windows fullscreen.
 
-## Highlights
+## Fixed
 
-- **Continue Watching** - pick up movies and episodes where you left off, with autoplay-next-episode plus an end-of-episode "Up Next" prompt, and a Continue Watching row on the Movies and Series homes (#66-#68)
-- **Live sports matchup logos** - team logos appear in the Now Playing bar for recognized games, with a settings toggle (default on)
-- **Fullscreen mode** - f / F11 / player button to enter, Esc to exit, with the title bar still reachable
-- **Provider category order** - keep your provider's original category arrangement instead of forced alphabetical (#48)
-- **Toast notifications** - a unified toast system for sync progress, successes, and failures (#11, #71)
-- **Scroll-to-top** - re-click the active category to jump its list back to the top
+- **Windows fullscreen** - pressing f, F11, or the player's fullscreen button now covers the entire screen, taskbar included, instead of only maximizing the window, and exits cleanly with Esc, f, F11, or the title-bar control (#76).
 
-See CHANGELOG.md for the full list.
+macOS and Linux fullscreen are unchanged.
+
+See CHANGELOG.md for the full history.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtltv",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.8.1-test",
+  "version": "0.8.1",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.8.0",
+  "version": "0.8.1-test",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -46,6 +46,10 @@ let mpvBridge: MpvTextureBridgeType | null = null;
 
 // Track mpv state
 let isShuttingDown = false; // Track if we're intentionally closing
+// Windows fullscreen state — tracked manually because setFullScreen's enter/leave-full-screen
+// events don't fire on the transparent frameless window (and isFullScreen() reads stale there),
+// so we drive the renderer's fullscreen state from this boolean instead.
+let windowsFullscreen = false;
 interface MpvState {
   playing: boolean;
   volume: number;
@@ -232,12 +236,13 @@ async function createWindow(): Promise<void> {
   });
 
   // Drive the renderer's "fullscreen" state (button icon + Esc-to-exit). macOS uses true OS
-  // fullscreen events; Windows/Linux use maximize state (setFullScreen is unreliable on the
-  // transparent window, so "fullscreen" == maximize there).
+  // fullscreen events; Linux uses maximize state. Windows is driven directly from the
+  // window-set-fullscreen handler — setFullScreen DOES cover the screen on the transparent
+  // frameless window, but enter/leave-full-screen never fire there, so events are unreliable.
   if (process.platform === 'darwin') {
     mainWindow.on('enter-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', true));
     mainWindow.on('leave-full-screen', () => mainWindow?.webContents.send('window-fullscreen-changed', false));
-  } else {
+  } else if (process.platform === 'linux') {
     mainWindow.on('maximize', () => mainWindow?.webContents.send('window-fullscreen-changed', true));
     mainWindow.on('unmaximize', () => mainWindow?.webContents.send('window-fullscreen-changed', false));
   }
@@ -778,14 +783,19 @@ ipcMain.handle('window-set-size', (_event, width: number, height: number) => {
 
 ipcMain.handle('window-set-fullscreen', () => {
   if (!mainWindow) return;
-  if (process.platform === 'darwin') {
-    // macOS: opaque window + native mpv texture — true OS fullscreen works.
+  if (process.platform === 'win32') {
+    // Windows: transparent frameless window. setFullScreen DOES cover the whole screen
+    // (taskbar included), but enter/leave-full-screen never fire and isFullScreen() reads
+    // stale here — so track the state ourselves and drive the renderer directly. The embedded
+    // --wid mpv child fills the parent's client area, so it follows the window into fullscreen.
+    windowsFullscreen = !windowsFullscreen;
+    mainWindow.setFullScreen(windowsFullscreen);
+    mainWindow.webContents.send('window-fullscreen-changed', windowsFullscreen);
+  } else if (process.platform === 'darwin') {
+    // macOS: opaque window + native mpv texture — true OS fullscreen + enter/leave events work.
     mainWindow.setFullScreen(!mainWindow.isFullScreen());
   } else {
-    // Windows/Linux: window is transparent (external mpv renders behind) and Electron's
-    // setFullScreen is unreliable on transparent windows — maximize is the working equivalent.
-    // (A "real" taskbar-covering Windows fullscreen would need the transparent/external-mpv
-    // model reworked; deferred.)
+    // Linux: separate mpv window; setFullScreen is unreliable, maximize is the working equivalent.
     if (mainWindow.isMaximized()) mainWindow.unmaximize();
     else mainWindow.maximize();
   }


### PR DESCRIPTION
Promotes 0.8.1 to main for release. Single fix: Windows taskbar-covering fullscreen (#76). macOS/Linux unchanged. CHANGELOG + RELEASE_NOTES + version 0.8.1 included.