### PR TITLE
fix(updater): clickable update-notification buttons (0.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.2] - 2026-06-08
+
+### Fixed
+- **Update notification button** - the "Restart" and "Later" buttons on the in-app update notification are clickable again. They had become unresponsive when the update chip was folded into the toast stack (the container disabled pointer events without re-enabling them on the chip). Updating from Settings was unaffected
+
 ## [0.8.1] - 2026-06-08
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,9 @@
-# sbtlTV 0.8.1
+# sbtlTV 0.8.2
 
-A small fix-up release for Windows fullscreen.
+A small fix-up release for the in-app updater.
 
 ## Fixed
 
-- **Windows fullscreen** - pressing f, F11, or the player's fullscreen button now covers the entire screen, taskbar included, instead of only maximizing the window, and exits cleanly with Esc, f, F11, or the title-bar control (#76).
-
-macOS and Linux fullscreen are unchanged.
+- **Update notification button** - the "Restart" and "Later" buttons on the in-app update notification are clickable again. They had become unresponsive after the update chip moved into the toast stack; updating from Settings was unaffected.
 
 See CHANGELOG.md for the full history.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtltv",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {

--- a/packages/ui/src/components/toast/Toast.css
+++ b/packages/ui/src/components/toast/Toast.css
@@ -10,7 +10,8 @@
   gap: 10px;
   pointer-events: none;
 }
-.toast-container .toast {
+.toast-container .toast,
+.toast-container .update-notification {
   pointer-events: auto;
 }
 


### PR DESCRIPTION
The in-app update notification's Restart/Later buttons were unclickable since the 0.8.0 toast refactor: the update chip is mounted inside .toast-container (pointer-events: none) but only .toast re-enabled pointer events, so clicks passed through the chip. One-line CSS fix re-enables pointer-events on .update-notification. Handlers were already correct; updating via Settings was unaffected. Includes 0.8.2 bump + CHANGELOG + RELEASE_NOTES.