### PR TITLE
Channel search + resizable channel column + name tooltip + VOD hover fix (0.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtltv",
-  "version": "0.8.2",
+  "version": "0.9.0-test",
   "private": true,
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.8.2",
+  "version": "0.9.0-test",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {

--- a/packages/electron/src/storage.ts
+++ b/packages/electron/src/storage.ts
@@ -38,6 +38,7 @@ interface AppSettings {
   categorySortOrder?: 'alphabetical' | 'provider';  // Live category strip ordering (default: alphabetical)
   autoUpdateEnabled?: boolean;  // Auto-check for updates on launch (default true)
   categoryBarWidth?: number;    // Category strip content width in px (default 160)
+  channelColumnWidth?: number;  // Guide channel-info column width in px (default 300)
   guideOpacity?: number;        // Background opacity for EPG/category/title bar (default 0.95)
   liveSourceOrder?: string[];   // Source IDs in priority order for live TV
   vodSourceOrder?: string[];    // Source IDs in priority order for VOD (Xtream only)
@@ -62,6 +63,7 @@ interface StoredSettings {
   categorySortOrder?: 'alphabetical' | 'provider';  // Live category strip ordering
   autoUpdateEnabled?: boolean;  // Auto-check for updates on launch
   categoryBarWidth?: number;    // Category strip content width in px
+  channelColumnWidth?: number;  // Guide channel-info column width in px
   guideOpacity?: number;        // Background opacity for EPG/category/title bar
   liveSourceOrder?: string[];   // Source IDs in priority order for live TV
   vodSourceOrder?: string[];    // Source IDs in priority order for VOD
@@ -208,6 +210,7 @@ export function getSettings(): AppSettings {
   result.categorySortOrder = stored.categorySortOrder ?? 'alphabetical';
   result.autoUpdateEnabled = stored.autoUpdateEnabled ?? true;
   result.categoryBarWidth = stored.categoryBarWidth ?? 160;
+  result.channelColumnWidth = stored.channelColumnWidth ?? 300;
   result.guideOpacity = stored.guideOpacity ?? 0.95;
   result.liveSourceOrder = stored.liveSourceOrder;
   result.vodSourceOrder = stored.vodSourceOrder;
@@ -255,6 +258,9 @@ export function updateSettings(settings: Partial<AppSettings>): void {
   }
   if (settings.categoryBarWidth !== undefined) {
     updated.categoryBarWidth = settings.categoryBarWidth;
+  }
+  if (settings.channelColumnWidth !== undefined) {
+    updated.channelColumnWidth = settings.channelColumnWidth;
   }
   if (settings.guideOpacity !== undefined) {
     updated.guideOpacity = settings.guideOpacity;

--- a/packages/ui/src/components/ChannelPanel.css
+++ b/packages/ui/src/components/ChannelPanel.css
@@ -443,10 +443,28 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 2px;
+  border-radius: 4px;
   transition: color 0.15s ease;
 }
 
 .guide-search-clear:hover {
   color: rgba(255, 255, 255, 0.8);
+}
+
+/* Very narrow windows: drop the search box onto its own full-width line below the nav/close,
+   so a slim horizontal layout doesn't crowd or overflow the guide header. */
+@media (max-width: 860px) {
+  .guide-header-right {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .guide-search-wrapper {
+    order: 1; /* push the search after (below) the nav + close buttons */
+    flex-basis: 100%;
+    margin-top: 8px;
+  }
+  .guide-search-input {
+    width: 100%;
+    box-sizing: border-box;
+  }
 }

--- a/packages/ui/src/components/ChannelPanel.css
+++ b/packages/ui/src/components/ChannelPanel.css
@@ -395,3 +395,58 @@
   font-size: 0.8rem;
   color: rgba(255, 255, 255, 0.3);
 }
+
+/* Channel search (in guide header) */
+.guide-search-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.guide-search-icon {
+  position: absolute;
+  left: 8px;
+  color: rgba(255, 255, 255, 0.35);
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.guide-search-input {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.8rem;
+  padding: 4px 28px;
+  width: 180px;
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.guide-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.guide-search-input:focus {
+  border-color: rgba(0, 212, 255, 0.4);
+  background: rgba(0, 212, 255, 0.15);
+}
+
+.guide-search-clear {
+  position: absolute;
+  right: 6px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  transition: color 0.15s ease;
+}
+
+.guide-search-clear:hover {
+  color: rgba(255, 255, 255, 0.8);
+}

--- a/packages/ui/src/components/ChannelPanel.tsx
+++ b/packages/ui/src/components/ChannelPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { useChannels, useCategories, useProgramsInRange } from '../hooks/useChannels';
 import { useFavoriteChannels } from '../hooks/useFavorites';
@@ -65,8 +65,9 @@ export function ChannelPanel({
   }, [searchQuery]);
 
   // Clear the search when switching categories - the search is scoped to the current category,
-  // so a leftover query would filter the new category against the wrong term.
-  useEffect(() => {
+  // so a leftover query would filter the new category against the wrong term. useLayoutEffect so
+  // the clear lands before paint (no one-frame flash of the new category filtered by the old query).
+  useLayoutEffect(() => {
     setSearchQuery('');
   }, [categoryId]);
 

--- a/packages/ui/src/components/ChannelPanel.tsx
+++ b/packages/ui/src/components/ChannelPanel.tsx
@@ -4,12 +4,10 @@ import { useChannels, useCategories, useProgramsInRange } from '../hooks/useChan
 import { useFavoriteChannels } from '../hooks/useFavorites';
 import { useTimeGrid } from '../hooks/useTimeGrid';
 import { ChannelRow } from './ChannelRow';
-import { useChannelSortOrder } from '../stores/uiStore';
+import { useChannelSortOrder, useChannelColumnWidth } from '../stores/uiStore';
 import type { StoredChannel } from '../db';
+import { filterChannelsByName } from '../utils/channelFilter';
 import './ChannelPanel.css';
-
-// Width of the channel info column
-const CHANNEL_COLUMN_WIDTH = 280;
 
 interface ChannelPanelProps {
   categoryId: string | null;
@@ -38,6 +36,18 @@ export function ChannelPanel({
   const categories = useCategories();
   const [currentTime, setCurrentTime] = useState(new Date());
   const [availableWidth, setAvailableWidth] = useState(800);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Channels filtered by the in-guide search box; the FULL list still drives EPG/program lookups.
+  const displayChannels = useMemo(() => filterChannelsByName(channels, searchQuery), [channels, searchQuery]);
+
+  // Channel column width is a persisted setting; the EFFECTIVE width yields a bit on narrow
+  // windows so the EPG grid never drops below 200px. The ref lets the mount-once ResizeObserver
+  // / resize listener read the live setting value instead of a stale closure.
+  const channelColumnWidth = useChannelColumnWidth();
+  const channelColumnWidthRef = useRef(channelColumnWidth);
+  channelColumnWidthRef.current = channelColumnWidth;
+  const [effectiveColumnWidth, setEffectiveColumnWidth] = useState(channelColumnWidth);
 
   // Ref for measuring the grid container width
   const gridContainerRef = useRef<HTMLDivElement>(null);
@@ -49,32 +59,41 @@ export function ChannelPanel({
     channelListRef.current?.scrollToIndex({ index: 0 });
   }, [scrollTopNonce]);
 
+  // Scroll the channel list to top whenever the search query changes.
+  useEffect(() => {
+    channelListRef.current?.scrollToIndex({ index: 0 });
+  }, [searchQuery]);
+
   // Track window width to differentiate window resize vs category toggle
   const lastWindowWidth = useRef(typeof window !== 'undefined' ? window.innerWidth : 0);
 
-  // Measure available width - only recalculate on actual window resize
-  // Category toggles just clip visually (CSS flex handles it)
+  // Recompute the effective column width + remaining grid width from the live container size.
+  // effective = min(setting, container - 200) so a narrow window lets the column yield rather
+  // than starving the EPG; availableWidth = container - effective (floored at 200).
+  const measureWidths = useCallback(() => {
+    const container = gridContainerRef.current;
+    if (!container) return;
+    const containerWidth = container.getBoundingClientRect().width;
+    const effective = Math.min(channelColumnWidthRef.current, Math.max(0, containerWidth - 200));
+    setEffectiveColumnWidth(effective);
+    setAvailableWidth(Math.max(containerWidth - effective, 200));
+  }, []);
+
+  // Measure on actual window resize only (category toggles just clip visually - CSS flex handles it).
   useEffect(() => {
     const container = gridContainerRef.current;
     if (!container) return;
 
     let rafId: number | null = null;
 
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-
+    const observer = new ResizeObserver(() => {
       const currentWindowWidth = window.innerWidth;
       const isWindowResize = currentWindowWidth !== lastWindowWidth.current;
-
       if (isWindowResize) {
-        // Actual window resize - recalculate program positions
         lastWindowWidth.current = currentWindowWidth;
-
         if (rafId === null) {
           rafId = requestAnimationFrame(() => {
-            const width = entry.contentRect.width - CHANNEL_COLUMN_WIDTH;
-            setAvailableWidth(Math.max(width, 200));
+            measureWidths();
             rafId = null;
           });
         }
@@ -82,19 +101,12 @@ export function ChannelPanel({
       // Category toggle: skip recalculation, CSS flex handles visual clipping
     });
 
-    // Also listen for actual window resize
     const handleWindowResize = () => {
-      const container = gridContainerRef.current;
-      if (!container) return;
-
       lastWindowWidth.current = window.innerWidth;
-      const width = container.getBoundingClientRect().width - CHANNEL_COLUMN_WIDTH;
-      setAvailableWidth(Math.max(width, 200));
+      measureWidths();
     };
 
-    // Set initial width
-    const initialWidth = container.getBoundingClientRect().width - CHANNEL_COLUMN_WIDTH;
-    setAvailableWidth(Math.max(initialWidth, 200));
+    measureWidths(); // initial
 
     observer.observe(container);
     window.addEventListener('resize', handleWindowResize);
@@ -104,7 +116,12 @@ export function ChannelPanel({
       observer.disconnect();
       window.removeEventListener('resize', handleWindowResize);
     };
-  }, []);
+  }, [measureWidths]);
+
+  // Recompute when the channel column width setting (slider) changes.
+  useEffect(() => {
+    measureWidths();
+  }, [channelColumnWidth, measureWidths]);
 
   // Time grid state and actions
   const {
@@ -207,9 +224,43 @@ export function ChannelPanel({
         <div className="guide-header-left">
           <span className="guide-current-time">{formatTime(currentTime)}</span>
           <span className="guide-category">{categoryName}</span>
-          <span className="guide-channel-count">{channels.length} channels</span>
+          <span className="guide-channel-count">
+            {searchQuery.trim() ? `${displayChannels.length} of ${channels.length}` : `${channels.length} channels`}
+          </span>
         </div>
         <div className="guide-header-right">
+          {/* Channel search */}
+          <div className="guide-search-wrapper">
+            <svg className="guide-search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+            </svg>
+            <input
+              className="guide-search-input"
+              type="text"
+              placeholder="Search channels…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape' && searchQuery) {
+                  setSearchQuery('');
+                  e.stopPropagation();
+                }
+              }}
+            />
+            {searchQuery && (
+              <button
+                className="guide-search-clear"
+                onClick={() => setSearchQuery('')}
+                title="Clear search"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
+
           {/* Navigation controls */}
           <div className="guide-nav">
             <button className="guide-nav-btn" onClick={goBack} title="Previous hour (←)">
@@ -242,7 +293,7 @@ export function ChannelPanel({
 
       {/* Time Header - Aligned to grid */}
       <div className="guide-time-header">
-        <div className="guide-time-header-spacer" style={{ width: CHANNEL_COLUMN_WIDTH }} />
+        <div className="guide-time-header-spacer" style={{ width: effectiveColumnWidth }} />
         <div className="guide-time-header-grid">
           {timeSlots.map((slot, i) => {
             const position = getTimeSlotPosition(slot);
@@ -265,13 +316,14 @@ export function ChannelPanel({
       <div className="guide-content">
         <Virtuoso
           ref={channelListRef}
-          data={channels}
+          data={displayChannels}
           className="guide-channels"
           itemContent={(index, channel) => (
             <ChannelRow
               channel={channel}
               index={index}
               sortOrder={channelSortOrder}
+              channelColumnWidth={effectiveColumnWidth}
               programs={programs.get(channel.stream_id) ?? []}
               windowStart={windowStart}
               windowEnd={windowEnd}
@@ -289,9 +341,18 @@ export function ChannelPanel({
                     <path d="M17 2l-5 5-5-5" />
                   </svg>
                 </div>
-                <h3>No Channels</h3>
-                <p>Sync your sources to load channels</p>
-                <p className="hint">Go to Settings → Add a source → Channels will sync automatically</p>
+                {searchQuery.trim() ? (
+                  <>
+                    <h3>No results for "{searchQuery}"</h3>
+                    <p>Try a different search term</p>
+                  </>
+                ) : (
+                  <>
+                    <h3>No Channels</h3>
+                    <p>Sync your sources to load channels</p>
+                    <p className="hint">Go to Settings → Add a source → Channels will sync automatically</p>
+                  </>
+                )}
               </div>
             ),
           }}

--- a/packages/ui/src/components/ChannelPanel.tsx
+++ b/packages/ui/src/components/ChannelPanel.tsx
@@ -64,6 +64,12 @@ export function ChannelPanel({
     channelListRef.current?.scrollToIndex({ index: 0 });
   }, [searchQuery]);
 
+  // Clear the search when switching categories - the search is scoped to the current category,
+  // so a leftover query would filter the new category against the wrong term.
+  useEffect(() => {
+    setSearchQuery('');
+  }, [categoryId]);
+
   // Track window width to differentiate window resize vs category toggle
   const lastWindowWidth = useRef(typeof window !== 'undefined' ? window.innerWidth : 0);
 
@@ -317,6 +323,7 @@ export function ChannelPanel({
         <Virtuoso
           ref={channelListRef}
           data={displayChannels}
+          computeItemKey={(_, channel) => channel.stream_id}
           className="guide-channels"
           itemContent={(index, channel) => (
             <ChannelRow

--- a/packages/ui/src/components/ChannelRow.tsx
+++ b/packages/ui/src/components/ChannelRow.tsx
@@ -3,13 +3,11 @@ import { ProgramBlock, EmptyProgramBlock } from './ProgramBlock';
 import { useIsFavoriteChannel, useToggleFavoriteChannel } from '../hooks/useFavorites';
 import type { StoredChannel, StoredProgram } from '../db';
 
-// Width of the channel info column (must match ChannelPanel)
-const CHANNEL_COLUMN_WIDTH = 280;
-
 interface ChannelRowProps {
   channel: StoredChannel;
   index: number;
   sortOrder: 'alphabetical' | 'number';
+  channelColumnWidth: number;
   programs: StoredProgram[];
   windowStart: Date;
   windowEnd: Date;
@@ -22,6 +20,7 @@ export const ChannelRow = memo(function ChannelRow({
   channel,
   index,
   sortOrder,
+  channelColumnWidth,
   programs,
   windowStart,
   windowEnd,
@@ -45,7 +44,7 @@ export const ChannelRow = memo(function ChannelRow({
       {/* Channel info column */}
       <div
         className="guide-channel-info"
-        style={{ width: CHANNEL_COLUMN_WIDTH, minWidth: CHANNEL_COLUMN_WIDTH }}
+        style={{ width: channelColumnWidth, minWidth: channelColumnWidth }}
         onClick={onPlay}
       >
         <span className="guide-channel-number">{displayNumber}</span>
@@ -62,7 +61,7 @@ export const ChannelRow = memo(function ChannelRow({
             <span className="logo-placeholder">{channel.name.charAt(0)}</span>
           )}
         </div>
-        <span className="guide-channel-name">{channel.name}</span>
+        <span className="guide-channel-name" title={channel.name}>{channel.name}</span>
         <button
           className={`channel-fav-btn${isFavorite ? ' active' : ''}`}
           onClick={handleToggleFavorite}

--- a/packages/ui/src/components/Settings.tsx
+++ b/packages/ui/src/components/Settings.tsx
@@ -56,6 +56,7 @@ export function Settings({ onClose }: SettingsProps) {
 
   // Guide appearance state
   const [categoryBarWidth, setCategoryBarWidth] = useState(160);
+  const [channelColumnWidth, setChannelColumnWidth] = useState(300);
   const [guideOpacity, setGuideOpacity] = useState(0.95);
 
   // Sports matchup state
@@ -138,6 +139,7 @@ export function Settings({ onClose }: SettingsProps) {
 
     // Load guide appearance settings
     setCategoryBarWidth(s.categoryBarWidth ?? 160);
+    setChannelColumnWidth(s.channelColumnWidth ?? 300);
     setGuideOpacity(s.guideOpacity ?? 0.95);
 
     // Load sports matchup setting (default ON)
@@ -209,8 +211,10 @@ export function Settings({ onClose }: SettingsProps) {
             categorySortOrder={categorySortOrder}
             onCategorySortOrderChange={setCategorySortOrder}
             categoryBarWidth={categoryBarWidth}
+            channelColumnWidth={channelColumnWidth}
             guideOpacity={guideOpacity}
             onCategoryBarWidthChange={setCategoryBarWidth}
+            onChannelColumnWidthChange={setChannelColumnWidth}
             onGuideOpacityChange={setGuideOpacity}
             sportsMatchupEnabled={sportsMatchupEnabled}
             onSportsMatchupChange={setSportsMatchupEnabled}

--- a/packages/ui/src/components/settings/EpgTab.tsx
+++ b/packages/ui/src/components/settings/EpgTab.tsx
@@ -10,8 +10,10 @@ interface EpgTabProps {
   categorySortOrder: 'alphabetical' | 'provider';
   onCategorySortOrderChange: (order: 'alphabetical' | 'provider') => void;
   categoryBarWidth: number;
+  channelColumnWidth: number;
   guideOpacity: number;
   onCategoryBarWidthChange: (width: number) => void;
+  onChannelColumnWidthChange: (width: number) => void;
   onGuideOpacityChange: (opacity: number) => void;
   sportsMatchupEnabled: boolean;
   onSportsMatchupChange: (enabled: boolean) => void;
@@ -23,8 +25,10 @@ export function EpgTab({
   categorySortOrder,
   onCategorySortOrderChange,
   categoryBarWidth,
+  channelColumnWidth,
   guideOpacity,
   onCategoryBarWidthChange,
+  onChannelColumnWidthChange,
   onGuideOpacityChange,
   sportsMatchupEnabled,
   onSportsMatchupChange,
@@ -83,6 +87,13 @@ export function EpgTab({
     updateSettings({ categoryBarWidth: width });
     if (!window.storage) return;
     await window.storage.updateSettings({ categoryBarWidth: width });
+  }
+
+  async function handleChannelWidthChange(width: number) {
+    onChannelColumnWidthChange(width);
+    updateSettings({ channelColumnWidth: width });
+    if (!window.storage) return;
+    await window.storage.updateSettings({ channelColumnWidth: width });
   }
 
   async function handleOpacityChange(pct: number) {
@@ -151,7 +162,7 @@ export function EpgTab({
         </div>
 
         <p className="section-description">
-          Adjust the category sidebar width and background opacity of the guide overlay.
+          Adjust the category sidebar width, channel column width, and background opacity of the guide overlay.
         </p>
 
         <div className="form-group">
@@ -165,6 +176,24 @@ export function EpgTab({
             value={categoryBarWidth}
             onChange={(e) => handleWidthChange(Number(e.target.value))}
             aria-label="Category sidebar width"
+          />
+          <div className="slider-labels">
+            <span>Narrow</span>
+            <span>Wide</span>
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label>Channel Column Width</label>
+          <input
+            type="range"
+            className="settings-slider"
+            min={220}
+            max={520}
+            step={10}
+            value={channelColumnWidth}
+            onChange={(e) => handleChannelWidthChange(Number(e.target.value))}
+            aria-label="Channel column width"
           />
           <div className="slider-labels">
             <span>Narrow</span>

--- a/packages/ui/src/components/vod/HorizontalCarousel.css
+++ b/packages/ui/src/components/vod/HorizontalCarousel.css
@@ -87,7 +87,10 @@
 .carousel__track {
   display: flex;
   gap: 12px;
-  padding: 4px 48px 12px;
+  /* Top-weighted padding gives the hover scale(1.05) headroom so it isn't clipped by the
+     carousel's fixed height + overflow:hidden. Net vertical padding unchanged (16px) so the
+     row height and Virtuoso fixedItemHeight stay constant. */
+  padding: 12px 48px 4px;
 }
 
 /* Scroll fade indicators */
@@ -155,7 +158,7 @@
   }
 
   .carousel__track {
-    padding: 4px 24px 12px;
+    padding: 12px 24px 4px;
     gap: 10px;
   }
 

--- a/packages/ui/src/stores/uiStore.test.ts
+++ b/packages/ui/src/stores/uiStore.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUIStore } from './uiStore';
+
+// Snapshot the default settings so each test starts clean.
+const DEFAULTS = { ...useUIStore.getState().settings };
+const reset = () => useUIStore.setState({ settings: { ...DEFAULTS } });
+
+describe('uiStore settings — channelColumnWidth', () => {
+  beforeEach(reset);
+
+  it('defaults to 300', () => {
+    expect(useUIStore.getState().settings.channelColumnWidth).toBe(300);
+  });
+
+  it('clamps below the minimum to 220', () => {
+    useUIStore.getState().updateSettings({ channelColumnWidth: 100 });
+    expect(useUIStore.getState().settings.channelColumnWidth).toBe(220);
+  });
+
+  it('clamps above the maximum to 520', () => {
+    useUIStore.getState().updateSettings({ channelColumnWidth: 999 });
+    expect(useUIStore.getState().settings.channelColumnWidth).toBe(520);
+  });
+
+  it('leaves an in-range value unchanged', () => {
+    useUIStore.getState().updateSettings({ channelColumnWidth: 360 });
+    expect(useUIStore.getState().settings.channelColumnWidth).toBe(360);
+  });
+});

--- a/packages/ui/src/stores/uiStore.ts
+++ b/packages/ui/src/stores/uiStore.ts
@@ -165,12 +165,13 @@ export const useUIStore = create<UIState>((set) => ({
   hydrateSettings: (data) => set({ settings: { ...DEFAULT_SETTINGS, ...data }, settingsLoaded: true }),
   updateSettings: (partial) => set((state) => {
     const merged = { ...state.settings, ...partial };
-    // Clamp categoryBarWidth (120-400) and guideOpacity (0.5-1.0)
+    // Clamp categoryBarWidth (120-400), channelColumnWidth (220-520), and guideOpacity (0.5-1.0)
     if (partial.categoryBarWidth !== undefined) {
       merged.categoryBarWidth = Math.max(120, Math.min(400, merged.categoryBarWidth ?? 160));
     }
     if (partial.channelColumnWidth !== undefined) {
-      merged.channelColumnWidth = Math.max(220, Math.min(520, merged.channelColumnWidth ?? 300));
+      const val = merged.channelColumnWidth ?? 300;
+      merged.channelColumnWidth = Number.isNaN(val) ? 300 : Math.max(220, Math.min(520, val));
     }
     if (partial.guideOpacity !== undefined) {
       const val = merged.guideOpacity ?? 0.95;

--- a/packages/ui/src/stores/uiStore.ts
+++ b/packages/ui/src/stores/uiStore.ts
@@ -96,6 +96,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   channelSortOrder: 'alphabetical',
   categorySortOrder: 'alphabetical',
   categoryBarWidth: 160,
+  channelColumnWidth: 300,
   guideOpacity: 0.95,
   vodRefreshHours: 24,
   epgRefreshHours: 6,
@@ -168,6 +169,9 @@ export const useUIStore = create<UIState>((set) => ({
     if (partial.categoryBarWidth !== undefined) {
       merged.categoryBarWidth = Math.max(120, Math.min(400, merged.categoryBarWidth ?? 160));
     }
+    if (partial.channelColumnWidth !== undefined) {
+      merged.channelColumnWidth = Math.max(220, Math.min(520, merged.channelColumnWidth ?? 300));
+    }
     if (partial.guideOpacity !== undefined) {
       const val = merged.guideOpacity ?? 0.95;
       merged.guideOpacity = Number.isNaN(val) ? 0.95 : Math.max(0.5, Math.min(1.0, val));
@@ -223,6 +227,7 @@ export const useSetCacheClearing = () => useUIStore((s) => s.setCacheClearing);
 export const useChannelSortOrder = () => useUIStore((s) => s.settings.channelSortOrder ?? 'alphabetical');
 export const useCategorySortOrder = () => useUIStore((s) => s.settings.categorySortOrder ?? 'alphabetical');
 export const useCategoryBarWidth = () => useUIStore((s) => s.settings.categoryBarWidth ?? 160);
+export const useChannelColumnWidth = () => useUIStore((s) => s.settings.channelColumnWidth ?? 300);
 export const useGuideOpacity = () => useUIStore((s) => s.settings.guideOpacity ?? 0.95);
 export const useTmdbApiKey = () => useUIStore((s) => s.settings.tmdbApiKey ?? null);
 export const usePosterDbApiKey = () => useUIStore((s) => s.settings.posterDbApiKey ?? null);

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -71,6 +71,7 @@ export interface AppSettings {
   categorySortOrder?: 'alphabetical' | 'provider';  // Live category strip ordering (default: alphabetical)
   autoUpdateEnabled?: boolean;  // Auto-check for updates on launch (default true)
   categoryBarWidth?: number;    // Category strip content width in px (default 160)
+  channelColumnWidth?: number;  // Guide channel-info column width in px (default 300, clamped 220-520)
   guideOpacity?: number;        // Background opacity for EPG/category/title bar (default 0.95)
   liveSourceOrder?: string[];   // Source IDs in priority order for live TV
   vodSourceOrder?: string[];    // Source IDs in priority order for VOD (Xtream only)

--- a/packages/ui/src/utils/channelFilter.test.ts
+++ b/packages/ui/src/utils/channelFilter.test.ts
@@ -19,4 +19,9 @@ describe('filterChannelsByName', () => {
   it('returns an empty array when nothing matches', () => {
     expect(filterChannelsByName(channels, 'xyz')).toEqual([]);
   });
+
+  it('does not crash on a channel with a null/undefined name', () => {
+    const withBad = [{ name: null } as unknown as StoredChannel, ch('BBC One')];
+    expect(filterChannelsByName(withBad, 'bbc').map((c) => c.name)).toEqual(['BBC One']);
+  });
 });

--- a/packages/ui/src/utils/channelFilter.test.ts
+++ b/packages/ui/src/utils/channelFilter.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { filterChannelsByName } from './channelFilter';
+import type { StoredChannel } from '../db';
+
+const ch = (name: string): StoredChannel => ({ name } as StoredChannel);
+
+describe('filterChannelsByName', () => {
+  const channels = [ch('BBC One'), ch('CNN'), ch('bbc news'), ch('ESPN')];
+
+  it('returns the SAME array reference for an empty/whitespace query', () => {
+    expect(filterChannelsByName(channels, '')).toBe(channels);
+    expect(filterChannelsByName(channels, '   ')).toBe(channels);
+  });
+
+  it('matches case-insensitive substrings', () => {
+    expect(filterChannelsByName(channels, 'bbc').map((c) => c.name)).toEqual(['BBC One', 'bbc news']);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterChannelsByName(channels, 'xyz')).toEqual([]);
+  });
+});

--- a/packages/ui/src/utils/channelFilter.ts
+++ b/packages/ui/src/utils/channelFilter.ts
@@ -1,0 +1,13 @@
+import type { StoredChannel } from '../db';
+
+/**
+ * Filter channels by a case-insensitive substring of the channel name.
+ *
+ * Returns the original array BY IDENTITY when the query is empty/whitespace, so the channel
+ * list (Virtuoso `data`) doesn't see a new array reference on every keystroke-free render.
+ */
+export function filterChannelsByName(channels: StoredChannel[], query: string): StoredChannel[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return channels;
+  return channels.filter((ch) => ch.name.toLowerCase().includes(q));
+}

--- a/packages/ui/src/utils/channelFilter.ts
+++ b/packages/ui/src/utils/channelFilter.ts
@@ -9,5 +9,7 @@ import type { StoredChannel } from '../db';
 export function filterChannelsByName(channels: StoredChannel[], query: string): StoredChannel[] {
   const q = query.trim().toLowerCase();
   if (!q) return channels;
-  return channels.filter((ch) => ch.name.toLowerCase().includes(q));
+  // Guard the name: a channel with a null/undefined name from bad provider data must not crash
+  // the whole panel (this runs inside a useMemo in ChannelPanel).
+  return channels.filter((ch) => (ch.name ?? '').toLowerCase().includes(q));
 }


### PR DESCRIPTION
Channel search in the guide (per-category, adapted from @Herbrax's PR #82), a persisted Channel Column Width setting (slider mirroring categoryBarWidth, with a narrow-window guard), a channel-name tooltip, and a VOD home hover-clip fix. 4-agent plan review + 8-agent PR review, all self-verified; device-tested on all platforms; 138 tests green; auto-update path untouched. Co-authored with @Herbrax for the search.