### PR TITLE
Fix one-to-many EPG channel mappings

### DIFF
--- a/packages/ui/src/db/index.ts
+++ b/packages/ui/src/db/index.ts
@@ -105,7 +105,7 @@ export type MatchStrategy =
 
 // EPG channel mapping (external EPG → provider channels)
 export interface EpgMapping {
-  id: string;                  // `${source_id}::${epg_source}::${epg_channel_id}`
+  id: string;                  // `${source_id}::${epg_source}::${stream_id}`
   source_id: string;
   epg_channel_id: string;      // Provider's epg_channel_id
   xmltv_channel_id: string;    // Matched XMLTV channel ID

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -3,6 +3,7 @@ import { db, clearSourceData, clearVodData, type SourceMeta, type StoredProgram,
 import { assignCategoryPositions } from './categoryPosition';
 import { fetchAndParseM3U, XtreamClient, type XmltvProgram, type XmltvChannel } from '@sbtltv/local-adapter';
 import { matchChannelsToEpg } from '../services/epg-matcher';
+import { buildChannelMap } from '../services/epg-channel-map';
 import type { Source, Channel, Category, Movie, Series } from '@sbtltv/core';
 import { getEnrichedMovieExports, getEnrichedTvExports, findBestMatch, extractMatchParams } from '../services/tmdb-exports';
 import { useUIStore } from '../stores/uiStore';
@@ -242,25 +243,6 @@ async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[
   return { programs, channels };
 }
 
-// Build a channelMap (xmltv_channel_id → stream_id) using EPG mappings + exact fallback
-function buildChannelMap(channels: Channel[], mappings: EpgMapping[]): Map<string, string> {
-  const channelMap = new Map<string, string>();
-
-  // Mappings take priority (fuzzy-matched channels)
-  for (const m of mappings) {
-    channelMap.set(m.xmltv_channel_id, m.stream_id);
-  }
-
-  // Also include exact epg_channel_id matches as fallback (provider's own EPG case)
-  for (const ch of channels) {
-    if (ch.epg_channel_id && !channelMap.has(ch.epg_channel_id)) {
-      channelMap.set(ch.epg_channel_id, ch.stream_id);
-    }
-  }
-
-  return channelMap;
-}
-
 // Sync EPG from XMLTV URL(s) for M3U sources
 async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[]): Promise<EpgSyncResult> {
   debugLog(`Starting M3U EPG sync`, 'epg');
@@ -282,6 +264,9 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
       }
       const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
       debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
+      // Mapping IDs are stream-specific. Remove records written by older
+      // versions so duplicate/blank provider EPG IDs cannot leave stale rows.
+      await db.epgMappings.where('[source_id+epg_source]').equals([source.id, epgUrl]).delete();
       await db.epgMappings.bulkPut(mappings);
     }
 
@@ -296,17 +281,19 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
 
     for (let i = 0; i < xmltvPrograms.length; i++) {
       const prog = xmltvPrograms[i];
-      const streamId = channelMap.get(prog.channel_id);
-      if (streamId) {
-        storedPrograms.push({
-          id: `${source.id}-${streamId}-${prog.start.getTime()}`,
-          stream_id: streamId,
-          title: prog.title,
-          description: prog.description,
-          start: prog.start,
-          end: prog.stop,
-          source_id: source.id,
-        });
+      const streamIds = channelMap.get(prog.channel_id);
+      if (streamIds?.size) {
+        for (const streamId of streamIds) {
+          storedPrograms.push({
+            id: `${source.id}-${streamId}-${prog.start.getTime()}`,
+            stream_id: streamId,
+            title: prog.title,
+            description: prog.description,
+            start: prog.start,
+            end: prog.stop,
+            source_id: source.id,
+          });
+        }
       } else {
         unmatchedChannels.add(prog.channel_id);
       }
@@ -315,7 +302,7 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
       }
     }
 
-    debugLog(`Matched ${storedPrograms.length}/${xmltvPrograms.length} programs (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
+    debugLog(`Stored ${storedPrograms.length} program records from ${xmltvPrograms.length} XMLTV programmes (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
 
     // SAFETY: Only clear old data if we have new data to replace it
     if (storedPrograms.length === 0) {
@@ -380,6 +367,7 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<Ep
       }
       const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
       debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
+      await db.epgMappings.where('[source_id+epg_source]').equals([source.id, epgSource]).delete();
       await db.epgMappings.bulkPut(mappings);
     }
 
@@ -392,23 +380,25 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<Ep
     const unmatchedChannels = new Set<string>();
 
     for (const prog of xmltvPrograms) {
-      const streamId = channelMap.get(prog.channel_id);
-      if (streamId) {
-        storedPrograms.push({
-          id: `${source.id}-${streamId}-${prog.start.getTime()}`,
-          stream_id: streamId,
-          title: prog.title,
-          description: prog.description,
-          start: prog.start,
-          end: prog.stop,
-          source_id: source.id,
-        });
+      const streamIds = channelMap.get(prog.channel_id);
+      if (streamIds?.size) {
+        for (const streamId of streamIds) {
+          storedPrograms.push({
+            id: `${source.id}-${streamId}-${prog.start.getTime()}`,
+            stream_id: streamId,
+            title: prog.title,
+            description: prog.description,
+            start: prog.start,
+            end: prog.stop,
+            source_id: source.id,
+          });
+        }
       } else {
         unmatchedChannels.add(prog.channel_id);
       }
     }
 
-    debugLog(`Matched ${storedPrograms.length}/${xmltvPrograms.length} programs (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
+    debugLog(`Stored ${storedPrograms.length} program records from ${xmltvPrograms.length} XMLTV programmes (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
 
     // SAFETY: Only clear old data if we have new data to replace it
     if (storedPrograms.length === 0) {

--- a/packages/ui/src/services/epg-channel-map.test.ts
+++ b/packages/ui/src/services/epg-channel-map.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { Channel } from '@sbtltv/core';
+import type { EpgMapping } from '../db/index';
+import { buildChannelMap } from './epg-channel-map';
+
+function channel(streamId: string, epgChannelId: string): Channel {
+  return {
+    stream_id: streamId,
+    name: streamId,
+    stream_icon: '',
+    epg_channel_id: epgChannelId,
+    category_ids: [],
+    direct_url: `https://example.test/${streamId}`,
+    source_id: 'source',
+  };
+}
+
+function mapping(streamId: string, xmltvChannelId: string): EpgMapping {
+  return {
+    id: `source::epg::${streamId}`,
+    source_id: 'source',
+    epg_channel_id: 'shared.provider.id',
+    xmltv_channel_id: xmltvChannelId,
+    epg_source: 'epg',
+    stream_id: streamId,
+    confidence: 'exact',
+    strategy: 'exact_id',
+  };
+}
+
+describe('buildChannelMap', () => {
+  it('keeps every stream that maps to the same XMLTV channel', () => {
+    const channels = [
+      channel('sports-hd', 'sports.example'),
+      channel('sports-fhd', 'sports.example'),
+      channel('sports-hevc', 'sports.example'),
+    ];
+    const mappings = channels.map((item) => mapping(item.stream_id, 'sports.example'));
+
+    expect([...buildChannelMap(channels, mappings).get('sports.example')!]).toEqual([
+      'sports-hd',
+      'sports-fhd',
+      'sports-hevc',
+    ]);
+  });
+
+  it('fans out duplicate provider IDs through the exact fallback', () => {
+    const channels = [
+      channel('news-hd', 'news.example'),
+      channel('news-backup', 'news.example'),
+    ];
+
+    expect([...buildChannelMap(channels, []).get('news.example')!]).toEqual([
+      'news-hd',
+      'news-backup',
+    ]);
+  });
+
+  it('does not duplicate a stream present in both matching and fallback paths', () => {
+    const channels = [channel('movies-hd', 'movies.example')];
+
+    expect(buildChannelMap(channels, [mapping('movies-hd', 'movies.example')]).get('movies.example')?.size).toBe(1);
+  });
+});

--- a/packages/ui/src/services/epg-channel-map.ts
+++ b/packages/ui/src/services/epg-channel-map.ts
@@ -1,0 +1,40 @@
+import type { Channel } from '@sbtltv/core';
+import type { EpgMapping } from '../db/index';
+
+/**
+ * Build an XMLTV channel ID -> provider stream IDs lookup.
+ *
+ * Providers commonly expose several variants of the same channel (HD, FHD,
+ * HEVC, backup, and so on). Every variant must receive the shared XMLTV
+ * schedule, so the lookup is deliberately one-to-many.
+ */
+export function buildChannelMap(
+  channels: Channel[],
+  mappings: EpgMapping[],
+): Map<string, Set<string>> {
+  const channelMap = new Map<string, Set<string>>();
+
+  const addStream = (xmltvChannelId: string, streamId: string) => {
+    let streamIds = channelMap.get(xmltvChannelId);
+    if (!streamIds) {
+      streamIds = new Set<string>();
+      channelMap.set(xmltvChannelId, streamIds);
+    }
+    streamIds.add(streamId);
+  };
+
+  // Matcher results take priority, but do not overwrite sibling variants.
+  for (const mapping of mappings) {
+    addStream(mapping.xmltv_channel_id, mapping.stream_id);
+  }
+
+  // Also include provider-supplied exact IDs as a fallback. Adding all exact
+  // channels is intentional: multiple streams can share the same EPG ID.
+  for (const channel of channels) {
+    if (channel.epg_channel_id) {
+      addStream(channel.epg_channel_id, channel.stream_id);
+    }
+  }
+
+  return channelMap;
+}

--- a/packages/ui/src/services/epg-matcher.test.ts
+++ b/packages/ui/src/services/epg-matcher.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { Channel } from '@sbtltv/core';
+import { matchChannelsToEpg } from './epg-matcher';
+
+function channel(streamId: string): Channel {
+  return {
+    stream_id: streamId,
+    name: `Sports ${streamId}`,
+    stream_icon: '',
+    epg_channel_id: 'sports.example',
+    category_ids: [],
+    direct_url: `https://example.test/${streamId}`,
+    source_id: 'source',
+  };
+}
+
+describe('matchChannelsToEpg mapping identity', () => {
+  it('persists separate mappings for stream variants sharing an EPG ID', () => {
+    const mappings = matchChannelsToEpg(
+      [channel('hd'), channel('fhd'), channel('hevc')],
+      [{ id: 'sports.example', displayNames: ['Sports'] }],
+      'source',
+      'https://example.test/epg.xml',
+    );
+
+    expect(mappings).toHaveLength(3);
+    expect(new Set(mappings.map((mapping) => mapping.id)).size).toBe(3);
+    expect(mappings.map((mapping) => mapping.stream_id)).toEqual(['hd', 'fhd', 'hevc']);
+  });
+});

--- a/packages/ui/src/services/epg-matcher.ts
+++ b/packages/ui/src/services/epg-matcher.ts
@@ -115,7 +115,9 @@ export function matchChannelsToEpg(
     if (matched.has(ch.stream_id)) return;
     matched.add(ch.stream_id);
     mappings.push({
-      id: `${sourceId}::${epgSource}::${ch.epg_channel_id}`,
+      // stream_id makes the primary key unique when channel variants share an
+      // epg_channel_id (or when the provider leaves that ID blank).
+      id: `${sourceId}::${epgSource}::${ch.stream_id}`,
       source_id: sourceId,
       epg_channel_id: ch.epg_channel_id,
       xmltv_channel_id: xmltvId,


### PR DESCRIPTION
## Summary

- preserve every provider stream matched to the same XMLTV channel
- store EPG mappings with stream-specific IDs so channel variants cannot overwrite each other
- fan out each XMLTV programme to all matching streams
- clear stale mappings written by the previous one-to-one format during EPG sync

## Root cause

The final XMLTV lookup used `Map<string, string>`, so each additional provider
stream matched to an XMLTV channel replaced the previous stream. Persisted
mapping IDs were also based on the provider EPG channel ID, which was not unique
when HD, FHD, HEVC, or backup variants shared that ID.

The lookup is now `Map<string, Set<string>>`, and persisted mapping IDs include
`stream_id`.

## Impact

All provider channel variants matched to one XMLTV channel receive the same
programme listings. Existing one-to-one mappings continue to behave as before.

## Validation

- 19 UI test files passed
- 142 UI tests passed, including four new regression tests
- UI TypeScript type-check passed
- tested with a real IPTV provider containing multiple channel variants for the same XMLTV ID

Fixes #87
