### PR TITLE
fix(epg): fan out guide data to every matching channel variant (0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.1] - 2026-07-23
+
+### Fixed
+- **EPG for duplicate channel variants** - when a provider lists the same channel several times (HD, FHD, HEVC, backup), every variant now shows its guide data instead of only one of them. Reported and prototyped by @JiggsNephron (#87, #88)
+
 ## [0.9.0] - 2026-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.9.1] - 2026-07-23
+## [0.9.1] - 2026-07-24
 
 ### Fixed
 - **EPG for duplicate channel variants** - when a provider lists the same channel several times (HD, FHD, HEVC, backup), every variant now shows its guide data instead of only one of them. Applies on the next EPG refresh; if your EPG refresh is set to Manual only, use Sync Now to pick it up. Reported and prototyped by @JiggsNephron (#87, #88)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.9.1] - 2026-07-23
 
 ### Fixed
-- **EPG for duplicate channel variants** - when a provider lists the same channel several times (HD, FHD, HEVC, backup), every variant now shows its guide data instead of only one of them. Reported and prototyped by @JiggsNephron (#87, #88)
+- **EPG for duplicate channel variants** - when a provider lists the same channel several times (HD, FHD, HEVC, backup), every variant now shows its guide data instead of only one of them. Applies on the next EPG refresh; if your EPG refresh is set to Manual only, use Sync Now to pick it up. Reported and prototyped by @JiggsNephron (#87, #88)
 
 ## [0.9.0] - 2026-06-27
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,7 @@
-# sbtlTV 0.9.0
-
-## Added
-
-- **Channel search** - filter the channel list by name right from the guide header, per category. Contributed by [Herbrax](https://github.com/Herbrax) (#82).
-- **Resizable channel column** - a new Channel Column Width control under Settings > Guide Appearance lets you size the channel-info column to taste; it yields on very narrow windows so the program grid stays usable.
-- **Channel-name tooltip** - hover a long, truncated channel name to see the full name.
+# sbtlTV 0.9.1
 
 ## Fixed
 
-- **VOD home hover** - hovering a cover on the Movies and Series home no longer clips the top of the artwork as it zooms.
+- **EPG for duplicate channel variants** - when a provider lists the same channel several times (HD, FHD, HEVC, backup), every variant now shows its guide data instead of only one of them. Applies on the next EPG refresh; if your EPG refresh is set to Manual only, use Sync Now to pick it up. Reported and prototyped by [JiggsNephron](https://github.com/JiggsNephron) (#87, #88).
 
 See CHANGELOG.md for the full history.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtltv",
-  "version": "0.9.0",
+  "version": "0.9.1-test",
   "private": true,
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtltv",
-  "version": "0.9.1-test",
+  "version": "0.9.1",
   "private": true,
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.9.1-test",
+  "version": "0.9.1",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbtltv/electron",
-  "version": "0.9.0",
+  "version": "0.9.1-test",
   "description": "Desktop IPTV player with mpv",
   "homepage": "https://github.com/thesubtleties/sbtlTV",
   "author": {

--- a/packages/ui/src/db/epg-persistence.test.ts
+++ b/packages/ui/src/db/epg-persistence.test.ts
@@ -1,0 +1,88 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Channel } from '@sbtltv/core';
+import type { XmltvChannel, XmltvProgram } from '@sbtltv/local-adapter';
+import { db } from './index';
+import { matchChannelsToEpg } from '../services/epg-matcher';
+import { buildChannelMap, expandProgramToStreams } from '../services/epg-channel-map';
+
+// End-to-end persistence checks for the #87 fix. The pure helpers verify the
+// fan-out in memory; these verify the rows actually land in Dexie as N distinct
+// records rather than collapsing on a shared primary key (the original bug).
+
+const SOURCE = 'src-1';
+const EPG = 'https://example.test/epg.xml';
+
+function channel(streamId: string, epgChannelId: string): Channel {
+  return {
+    stream_id: streamId,
+    name: streamId,
+    stream_icon: '',
+    epg_channel_id: epgChannelId,
+    category_ids: [],
+    direct_url: `https://example.test/${streamId}`,
+    source_id: SOURCE,
+  };
+}
+
+function xmltvChannel(id: string): XmltvChannel {
+  return { id, displayNames: [id] };
+}
+
+function program(channelId: string, startMs: number): XmltvProgram {
+  return {
+    channel_id: channelId,
+    title: 'Match of the Day',
+    description: 'Highlights',
+    start: new Date(startMs),
+    stop: new Date(startMs + 3_600_000),
+  };
+}
+
+beforeEach(async () => {
+  await db.epgMappings.clear();
+  await db.programs.clear();
+});
+
+describe('#87 EPG mapping persistence', () => {
+  it('persists one mapping row per stream variant sharing an epg_channel_id', async () => {
+    const channels = [
+      channel('sports-hd', 'sports.example'),
+      channel('sports-fhd', 'sports.example'),
+      channel('sports-hevc', 'sports.example'),
+    ];
+    const mappings = matchChannelsToEpg(channels, [xmltvChannel('sports.example')], SOURCE, EPG);
+
+    await db.epgMappings.bulkPut(mappings);
+
+    // Old id format keyed on epg_channel_id collapsed all three onto one row here.
+    expect(await db.epgMappings.count()).toBe(3);
+    const stored = await db.epgMappings.where('source_id').equals(SOURCE).toArray();
+    expect(new Set(stored.map((m) => m.stream_id))).toEqual(
+      new Set(['sports-hd', 'sports-fhd', 'sports-hevc']),
+    );
+  });
+});
+
+describe('#87 EPG program persistence', () => {
+  it('writes a program row for every variant so each channel shows the guide', async () => {
+    const channels = [
+      channel('sports-hd', 'sports.example'),
+      channel('sports-fhd', 'sports.example'),
+      channel('sports-hevc', 'sports.example'),
+    ];
+    const mappings = matchChannelsToEpg(channels, [xmltvChannel('sports.example')], SOURCE, EPG);
+    const channelMap = buildChannelMap(channels, mappings);
+
+    const prog = program('sports.example', 1_700_000_000_000);
+    const records = expandProgramToStreams(prog, channelMap.get(prog.channel_id), SOURCE);
+    await db.programs.bulkPut(records);
+
+    expect(await db.programs.count()).toBe(3);
+    // Each variant can be read back on its own stream_id (the EPG grid keys on it).
+    for (const streamId of ['sports-hd', 'sports-fhd', 'sports-hevc']) {
+      const row = await db.programs.where('stream_id').equals(streamId).first();
+      expect(row?.title).toBe('Match of the Day');
+    }
+  });
+});

--- a/packages/ui/src/db/index.ts
+++ b/packages/ui/src/db/index.ts
@@ -105,7 +105,7 @@ export type MatchStrategy =
 
 // EPG channel mapping (external EPG → provider channels)
 export interface EpgMapping {
-  id: string;                  // `${source_id}::${epg_source}::${epg_channel_id}`
+  id: string;                  // `${source_id}::${epg_source}::${stream_id}`
   source_id: string;
   epg_channel_id: string;      // Provider's epg_channel_id
   xmltv_channel_id: string;    // Matched XMLTV channel ID

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -1,8 +1,9 @@
 import { type Table } from 'dexie';
-import { db, clearSourceData, clearVodData, type SourceMeta, type StoredProgram, type StoredMovie, type StoredSeries, type StoredEpisode, type VodCategory, type EpgMapping } from './index';
+import { db, clearSourceData, clearVodData, type SourceMeta, type StoredProgram, type StoredMovie, type StoredSeries, type StoredEpisode, type VodCategory } from './index';
 import { assignCategoryPositions } from './categoryPosition';
 import { fetchAndParseM3U, XtreamClient, type XmltvProgram, type XmltvChannel } from '@sbtltv/local-adapter';
 import { matchChannelsToEpg } from '../services/epg-matcher';
+import { buildChannelMap, expandProgramToStreams, summarizeFanOut } from '../services/epg-channel-map';
 import type { Source, Channel, Category, Movie, Series } from '@sbtltv/core';
 import { getEnrichedMovieExports, getEnrichedTvExports, findBestMatch, extractMatchParams } from '../services/tmdb-exports';
 import { useUIStore } from '../stores/uiStore';
@@ -242,23 +243,18 @@ async function fetchXmltvFromUrls(epgUrlStr: string, providerChannels?: Channel[
   return { programs, channels };
 }
 
-// Build a channelMap (xmltv_channel_id → stream_id) using EPG mappings + exact fallback
-function buildChannelMap(channels: Channel[], mappings: EpgMapping[]): Map<string, string> {
-  const channelMap = new Map<string, string>();
-
-  // Mappings take priority (fuzzy-matched channels)
-  for (const m of mappings) {
-    channelMap.set(m.xmltv_channel_id, m.stream_id);
-  }
-
-  // Also include exact epg_channel_id matches as fallback (provider's own EPG case)
-  for (const ch of channels) {
-    if (ch.epg_channel_id && !channelMap.has(ch.epg_channel_id)) {
-      channelMap.set(ch.epg_channel_id, ch.stream_id);
-    }
-  }
-
-  return channelMap;
+// Surface how wide the one-to-many EPG fan-out is. Every extra stream behind an
+// XMLTV channel multiplies the rows written to the programs table, so a provider
+// shipping a junk or over-shared epg_channel_id shows up here instead of silently
+// ballooning storage.
+function logFanOut(channelMap: Map<string, Set<string>>): void {
+  const fanOut = summarizeFanOut(channelMap);
+  if (fanOut.multiStreamChannels === 0) return;
+  debugLog(
+    `EPG fan-out: ${fanOut.multiStreamChannels} XMLTV channels feed multiple streams ` +
+    `(${fanOut.totalStreamLinks} total links, widest ${fanOut.maxFanOut}x on ${fanOut.maxFanOutChannelId})`,
+    'epg'
+  );
 }
 
 // Sync EPG from XMLTV URL(s) for M3U sources
@@ -282,12 +278,18 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
       }
       const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
       debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
-      await db.epgMappings.bulkPut(mappings);
+      // Mapping IDs are keyed on stream_id. Replace the whole set atomically so
+      // rows written by the older epg_channel_id format cannot linger.
+      await db.transaction('rw', db.epgMappings, async () => {
+        await db.epgMappings.where('[source_id+epg_source]').equals([source.id, epgUrl]).delete();
+        await db.epgMappings.bulkPut(mappings);
+      });
     }
 
     // Build channel map from mappings + exact fallback
     const channelMap = buildChannelMap(channels, mappings);
     debugLog(`Channel map has ${channelMap.size} entries`, 'epg');
+    logFanOut(channelMap);
 
     // Convert XMLTV programs to stored format (yield periodically for large datasets)
     const storedPrograms: StoredProgram[] = [];
@@ -296,17 +298,9 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
 
     for (let i = 0; i < xmltvPrograms.length; i++) {
       const prog = xmltvPrograms[i];
-      const streamId = channelMap.get(prog.channel_id);
-      if (streamId) {
-        storedPrograms.push({
-          id: `${source.id}-${streamId}-${prog.start.getTime()}`,
-          stream_id: streamId,
-          title: prog.title,
-          description: prog.description,
-          start: prog.start,
-          end: prog.stop,
-          source_id: source.id,
-        });
+      const records = expandProgramToStreams(prog, channelMap.get(prog.channel_id), source.id);
+      if (records.length > 0) {
+        storedPrograms.push(...records);
       } else {
         unmatchedChannels.add(prog.channel_id);
       }
@@ -315,7 +309,7 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
       }
     }
 
-    debugLog(`Matched ${storedPrograms.length}/${xmltvPrograms.length} programs (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
+    debugLog(`Stored ${storedPrograms.length} program records from ${xmltvPrograms.length} XMLTV programmes (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
 
     // SAFETY: Only clear old data if we have new data to replace it
     if (storedPrograms.length === 0) {
@@ -380,35 +374,33 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<Ep
       }
       const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
       debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
-      await db.epgMappings.bulkPut(mappings);
+      // Mapping IDs are keyed on stream_id. Replace the whole set atomically so
+      // rows written by the older epg_channel_id format cannot linger.
+      await db.transaction('rw', db.epgMappings, async () => {
+        await db.epgMappings.where('[source_id+epg_source]').equals([source.id, epgSource]).delete();
+        await db.epgMappings.bulkPut(mappings);
+      });
     }
 
     // Build channel map from mappings + exact fallback
     const channelMap = buildChannelMap(channels, mappings);
     debugLog(`Channel map has ${channelMap.size} entries`, 'epg');
+    logFanOut(channelMap);
 
     // Convert XMLTV programs to stored format
     const storedPrograms: StoredProgram[] = [];
     const unmatchedChannels = new Set<string>();
 
     for (const prog of xmltvPrograms) {
-      const streamId = channelMap.get(prog.channel_id);
-      if (streamId) {
-        storedPrograms.push({
-          id: `${source.id}-${streamId}-${prog.start.getTime()}`,
-          stream_id: streamId,
-          title: prog.title,
-          description: prog.description,
-          start: prog.start,
-          end: prog.stop,
-          source_id: source.id,
-        });
+      const records = expandProgramToStreams(prog, channelMap.get(prog.channel_id), source.id);
+      if (records.length > 0) {
+        storedPrograms.push(...records);
       } else {
         unmatchedChannels.add(prog.channel_id);
       }
     }
 
-    debugLog(`Matched ${storedPrograms.length}/${xmltvPrograms.length} programs (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
+    debugLog(`Stored ${storedPrograms.length} program records from ${xmltvPrograms.length} XMLTV programmes (${unmatchedChannels.size} unmatched EPG channels)`, 'epg');
 
     // SAFETY: Only clear old data if we have new data to replace it
     if (storedPrograms.length === 0) {

--- a/packages/ui/src/db/sync.ts
+++ b/packages/ui/src/db/sync.ts
@@ -278,12 +278,10 @@ async function syncEpgFromUrl(source: Source, epgUrl: string, channels: Channel[
       }
       const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
       debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
-      // Mapping IDs are keyed on stream_id. Replace the whole set atomically so
-      // rows written by the older epg_channel_id format cannot linger.
-      await db.transaction('rw', db.epgMappings, async () => {
-        await db.epgMappings.where('[source_id+epg_source]').equals([source.id, epgUrl]).delete();
-        await db.epgMappings.bulkPut(mappings);
-      });
+      // clearSourceData (syncSource) / the explicit clear in rematchEpg already
+      // wiped every epgMappings row for this source before we got here, so a plain
+      // put is enough - no stale rows from the older epg_channel_id id format survive.
+      await db.epgMappings.bulkPut(mappings);
     }
 
     // Build channel map from mappings + exact fallback
@@ -374,12 +372,10 @@ async function syncEpgForSource(source: Source, channels: Channel[]): Promise<Ep
       }
       const strategyStr = [...byStrategy.entries()].map(([s, n]) => `${s}=${n}`).join(', ');
       debugLog(`EPG matching: ${mappings.length}/${channels.length} channels matched (${strategyStr})`, 'epg');
-      // Mapping IDs are keyed on stream_id. Replace the whole set atomically so
-      // rows written by the older epg_channel_id format cannot linger.
-      await db.transaction('rw', db.epgMappings, async () => {
-        await db.epgMappings.where('[source_id+epg_source]').equals([source.id, epgSource]).delete();
-        await db.epgMappings.bulkPut(mappings);
-      });
+      // clearSourceData (syncSource) / the explicit clear in rematchEpg already
+      // wiped every epgMappings row for this source before we got here, so a plain
+      // put is enough - no stale rows from the older epg_channel_id id format survive.
+      await db.epgMappings.bulkPut(mappings);
     }
 
     // Build channel map from mappings + exact fallback

--- a/packages/ui/src/services/epg-channel-map.test.ts
+++ b/packages/ui/src/services/epg-channel-map.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import type { Channel } from '@sbtltv/core';
+import type { XmltvProgram } from '@sbtltv/local-adapter';
+import type { EpgMapping } from '../db/index';
+import { buildChannelMap, expandProgramToStreams, summarizeFanOut } from './epg-channel-map';
+
+function channel(streamId: string, epgChannelId: string): Channel {
+  return {
+    stream_id: streamId,
+    name: streamId,
+    stream_icon: '',
+    epg_channel_id: epgChannelId,
+    category_ids: [],
+    direct_url: `https://example.test/${streamId}`,
+    source_id: 'source',
+  };
+}
+
+function mapping(streamId: string, xmltvChannelId: string): EpgMapping {
+  return {
+    id: `source::epg::${streamId}`,
+    source_id: 'source',
+    epg_channel_id: 'shared.provider.id',
+    xmltv_channel_id: xmltvChannelId,
+    epg_source: 'epg',
+    stream_id: streamId,
+    confidence: 'exact',
+    strategy: 'exact_id',
+  };
+}
+
+function program(channelId: string, startMs: number): XmltvProgram {
+  return {
+    channel_id: channelId,
+    title: 'Match of the Day',
+    description: 'Highlights',
+    start: new Date(startMs),
+    stop: new Date(startMs + 3_600_000),
+  };
+}
+
+describe('buildChannelMap', () => {
+  it('keeps every stream that maps to the same XMLTV channel', () => {
+    const channels = [
+      channel('sports-hd', 'sports.example'),
+      channel('sports-fhd', 'sports.example'),
+      channel('sports-hevc', 'sports.example'),
+    ];
+    const mappings = channels.map((item) => mapping(item.stream_id, 'sports.example'));
+
+    expect([...buildChannelMap(channels, mappings).get('sports.example')!]).toEqual([
+      'sports-hd',
+      'sports-fhd',
+      'sports-hevc',
+    ]);
+  });
+
+  it('fans out duplicate provider IDs through the exact fallback', () => {
+    const channels = [
+      channel('news-hd', 'news.example'),
+      channel('news-backup', 'news.example'),
+    ];
+
+    expect([...buildChannelMap(channels, []).get('news.example')!]).toEqual([
+      'news-hd',
+      'news-backup',
+    ]);
+  });
+
+  it('does not duplicate a stream present in both matching and fallback paths', () => {
+    const channels = [channel('movies-hd', 'movies.example')];
+
+    expect(buildChannelMap(channels, [mapping('movies-hd', 'movies.example')]).get('movies.example')?.size).toBe(1);
+  });
+
+  it('ignores channels with a blank provider EPG ID', () => {
+    const channelMap = buildChannelMap([channel('no-epg', '')], []);
+
+    expect(channelMap.size).toBe(0);
+  });
+});
+
+describe('expandProgramToStreams', () => {
+  it('creates one record per matching stream with stream-specific IDs', () => {
+    const streams = new Set(['sports-hd', 'sports-fhd', 'sports-hevc']);
+
+    const records = expandProgramToStreams(program('sports.example', 1_700_000_000_000), streams, 'source');
+
+    expect(records.map((record) => record.stream_id)).toEqual(['sports-hd', 'sports-fhd', 'sports-hevc']);
+    expect(records.map((record) => record.id)).toEqual([
+      'source-sports-hd-1700000000000',
+      'source-sports-fhd-1700000000000',
+      'source-sports-hevc-1700000000000',
+    ]);
+  });
+
+  it('carries programme metadata across and maps stop to end', () => {
+    const prog = program('sports.example', 1_700_000_000_000);
+
+    const [record] = expandProgramToStreams(prog, new Set(['sports-hd']), 'source');
+
+    expect(record).toMatchObject({
+      title: 'Match of the Day',
+      description: 'Highlights',
+      start: prog.start,
+      end: prog.stop,
+      source_id: 'source',
+    });
+  });
+
+  it('returns nothing when the XMLTV channel matches no streams', () => {
+    expect(expandProgramToStreams(program('orphan.example', 1), undefined, 'source')).toEqual([]);
+    expect(expandProgramToStreams(program('orphan.example', 1), new Set(), 'source')).toEqual([]);
+  });
+});
+
+describe('summarizeFanOut', () => {
+  it('reports the widest fan-out and how many channels feed several streams', () => {
+    const channelMap = new Map([
+      ['sports.example', new Set(['hd', 'fhd', 'hevc'])],
+      ['news.example', new Set(['hd', 'backup'])],
+      ['movies.example', new Set(['hd'])],
+    ]);
+
+    expect(summarizeFanOut(channelMap)).toEqual({
+      multiStreamChannels: 2,
+      maxFanOut: 3,
+      maxFanOutChannelId: 'sports.example',
+      totalStreamLinks: 6,
+    });
+  });
+
+  it('handles an empty channel map', () => {
+    expect(summarizeFanOut(new Map())).toEqual({
+      multiStreamChannels: 0,
+      maxFanOut: 0,
+      maxFanOutChannelId: null,
+      totalStreamLinks: 0,
+    });
+  });
+});

--- a/packages/ui/src/services/epg-channel-map.test.ts
+++ b/packages/ui/src/services/epg-channel-map.test.ts
@@ -48,11 +48,10 @@ describe('buildChannelMap', () => {
     ];
     const mappings = channels.map((item) => mapping(item.stream_id, 'sports.example'));
 
-    expect([...buildChannelMap(channels, mappings).get('sports.example')!]).toEqual([
-      'sports-hd',
-      'sports-fhd',
-      'sports-hevc',
-    ]);
+    // Set equality, not array order: the contract is "every variant is present".
+    expect(buildChannelMap(channels, mappings).get('sports.example')).toEqual(
+      new Set(['sports-hd', 'sports-fhd', 'sports-hevc']),
+    );
   });
 
   it('fans out duplicate provider IDs through the exact fallback', () => {
@@ -61,10 +60,9 @@ describe('buildChannelMap', () => {
       channel('news-backup', 'news.example'),
     ];
 
-    expect([...buildChannelMap(channels, []).get('news.example')!]).toEqual([
-      'news-hd',
-      'news-backup',
-    ]);
+    expect(buildChannelMap(channels, []).get('news.example')).toEqual(
+      new Set(['news-hd', 'news-backup']),
+    );
   });
 
   it('does not duplicate a stream present in both matching and fallback paths', () => {
@@ -86,12 +84,18 @@ describe('expandProgramToStreams', () => {
 
     const records = expandProgramToStreams(program('sports.example', 1_700_000_000_000), streams, 'source');
 
-    expect(records.map((record) => record.stream_id)).toEqual(['sports-hd', 'sports-fhd', 'sports-hevc']);
-    expect(records.map((record) => record.id)).toEqual([
-      'source-sports-hd-1700000000000',
-      'source-sports-fhd-1700000000000',
-      'source-sports-hevc-1700000000000',
-    ]);
+    // One record per stream, matched by content rather than order.
+    expect(records).toHaveLength(3);
+    expect(new Set(records.map((record) => record.stream_id))).toEqual(
+      new Set(['sports-hd', 'sports-fhd', 'sports-hevc']),
+    );
+    expect(new Set(records.map((record) => record.id))).toEqual(
+      new Set([
+        'source-sports-hd-1700000000000',
+        'source-sports-fhd-1700000000000',
+        'source-sports-hevc-1700000000000',
+      ]),
+    );
   });
 
   it('carries programme metadata across and maps stop to end', () => {

--- a/packages/ui/src/services/epg-channel-map.ts
+++ b/packages/ui/src/services/epg-channel-map.ts
@@ -1,0 +1,99 @@
+import type { Channel } from '@sbtltv/core';
+import type { XmltvProgram } from '@sbtltv/local-adapter';
+import type { EpgMapping, StoredProgram } from '../db/index';
+
+/**
+ * Build an XMLTV channel ID -> provider stream IDs lookup.
+ *
+ * Providers commonly expose several variants of the same channel (HD, FHD,
+ * HEVC, backup, and so on). Every variant must receive the shared XMLTV
+ * schedule, so the lookup is deliberately one-to-many.
+ */
+export function buildChannelMap(
+  channels: Channel[],
+  mappings: EpgMapping[],
+): Map<string, Set<string>> {
+  const channelMap = new Map<string, Set<string>>();
+
+  const addStream = (xmltvChannelId: string, streamId: string) => {
+    let streamIds = channelMap.get(xmltvChannelId);
+    if (!streamIds) {
+      streamIds = new Set<string>();
+      channelMap.set(xmltvChannelId, streamIds);
+    }
+    streamIds.add(streamId);
+  };
+
+  // Matcher results take priority, but do not overwrite sibling variants.
+  for (const mapping of mappings) {
+    addStream(mapping.xmltv_channel_id, mapping.stream_id);
+  }
+
+  // Also include provider-supplied exact IDs as a fallback. Adding all exact
+  // channels is intentional: multiple streams can share the same EPG ID.
+  for (const channel of channels) {
+    if (channel.epg_channel_id) {
+      addStream(channel.epg_channel_id, channel.stream_id);
+    }
+  }
+
+  return channelMap;
+}
+
+/**
+ * Expand one XMLTV programme into a stored record for every stream that the
+ * programme's channel feeds. Returns an empty array when nothing matches, so
+ * the caller can treat that as "unmatched EPG channel".
+ */
+export function expandProgramToStreams(
+  prog: XmltvProgram,
+  streamIds: Set<string> | undefined,
+  sourceId: string,
+): StoredProgram[] {
+  if (!streamIds?.size) return [];
+
+  const startMs = prog.start.getTime();
+  return [...streamIds].map((streamId) => ({
+    id: `${sourceId}-${streamId}-${startMs}`,
+    stream_id: streamId,
+    title: prog.title,
+    description: prog.description,
+    start: prog.start,
+    end: prog.stop,
+    source_id: sourceId,
+  }));
+}
+
+export interface FanOutSummary {
+  multiStreamChannels: number;  // XMLTV channels feeding more than one stream
+  maxFanOut: number;            // widest single fan-out
+  maxFanOutChannelId: string | null;
+  totalStreamLinks: number;     // stored records per XMLTV programme set
+}
+
+/**
+ * Describe how wide the one-to-many fan-out is for this sync.
+ *
+ * Every extra stream behind an XMLTV channel multiplies the rows written to
+ * the programs table. A provider shipping a junk or over-shared epg_channel_id
+ * can therefore balloon storage, so we surface the shape in the debug log
+ * instead of failing silently.
+ */
+export function summarizeFanOut(channelMap: Map<string, Set<string>>): FanOutSummary {
+  let multiStreamChannels = 0;
+  let maxFanOut = 0;
+  let maxFanOutChannelId: string | null = null;
+  let totalStreamLinks = 0;
+
+  for (const [xmltvChannelId, streamIds] of channelMap) {
+    const fanOut = streamIds.size;
+    totalStreamLinks += fanOut;
+    if (fanOut > 1) multiStreamChannels++;
+    if (fanOut > maxFanOut) {
+      maxFanOut = fanOut;
+      maxFanOutChannelId = xmltvChannelId;
+    }
+  }
+
+  return { multiStreamChannels, maxFanOut, maxFanOutChannelId, totalStreamLinks };
+}

--- a/packages/ui/src/services/epg-channel-map.ts
+++ b/packages/ui/src/services/epg-channel-map.ts
@@ -24,7 +24,8 @@ export function buildChannelMap(
     streamIds.add(streamId);
   };
 
-  // Matcher results take priority, but do not overwrite sibling variants.
+  // Add matcher results first; the exact-id fallback below adds to the same set
+  // via Set.add (never replacing), so a stream can be reached through either path.
   for (const mapping of mappings) {
     addStream(mapping.xmltv_channel_id, mapping.stream_id);
   }
@@ -68,7 +69,7 @@ export interface FanOutSummary {
   multiStreamChannels: number;  // XMLTV channels feeding more than one stream
   maxFanOut: number;            // widest single fan-out
   maxFanOutChannelId: string | null;
-  totalStreamLinks: number;     // stored records per XMLTV programme set
+  totalStreamLinks: number;     // sum of fan-out widths across all XMLTV channels (storage multiplier)
 }
 
 /**

--- a/packages/ui/src/services/epg-matcher.test.ts
+++ b/packages/ui/src/services/epg-matcher.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { Channel } from '@sbtltv/core';
+import { matchChannelsToEpg } from './epg-matcher';
+
+function channel(streamId: string): Channel {
+  return {
+    stream_id: streamId,
+    name: `Sports ${streamId}`,
+    stream_icon: '',
+    epg_channel_id: 'sports.example',
+    category_ids: [],
+    direct_url: `https://example.test/${streamId}`,
+    source_id: 'source',
+  };
+}
+
+describe('matchChannelsToEpg mapping identity', () => {
+  it('persists separate mappings for stream variants sharing an EPG ID', () => {
+    const mappings = matchChannelsToEpg(
+      [channel('hd'), channel('fhd'), channel('hevc')],
+      [{ id: 'sports.example', displayNames: ['Sports'] }],
+      'source',
+      'https://example.test/epg.xml',
+    );
+
+    expect(mappings).toHaveLength(3);
+    expect(new Set(mappings.map((mapping) => mapping.id)).size).toBe(3);
+    expect(mappings.map((mapping) => mapping.stream_id)).toEqual(['hd', 'fhd', 'hevc']);
+  });
+});

--- a/packages/ui/src/services/epg-matcher.ts
+++ b/packages/ui/src/services/epg-matcher.ts
@@ -115,7 +115,9 @@ export function matchChannelsToEpg(
     if (matched.has(ch.stream_id)) return;
     matched.add(ch.stream_id);
     mappings.push({
-      id: `${sourceId}::${epgSource}::${ch.epg_channel_id}`,
+      // stream_id makes the primary key unique when channel variants share an
+      // epg_channel_id (or when the provider leaves that ID blank).
+      id: `${sourceId}::${epgSource}::${ch.stream_id}`,
       source_id: sourceId,
       epg_channel_id: ch.epg_channel_id,
       xmltv_channel_id: xmltvId,


### PR DESCRIPTION
## Summary

When a provider lists the same channel several times (HD, FHD, HEVC, backup), only one variant received EPG data. This fans the guide out to every matching variant.

Builds on the diagnosis and prototype in #88 by @JiggsNephron, who also reported #87 with the correct root cause and suggested fix. Credited via `Co-authored-by`.

## Root cause

Two independent lookups collapsed the match:

1. `buildChannelMap` keyed `xmltv_channel_id -> a single stream_id`, so each additional variant overwrote the previous one. **This is the user-visible bug.**
2. Persisted mapping IDs were keyed on `epg_channel_id`, which variants share, so `bulkPut` kept only the last row. This is a real data-integrity bug, but `epgMappings` is currently write-only (nothing reads it back), so it was not contributing to the symptom.

## Changes

- `buildChannelMap` now returns `Map<string, Set<string>>` and lives in `services/epg-channel-map.ts` (extracted from `db/sync.ts` so it is testable)
- Mapping IDs are keyed on `stream_id`, making the primary key unique per variant
- Each XMLTV programme expands to one stored record per matching stream, via a new pure `expandProgramToStreams` helper
- Mapping rows are replaced inside a `db.transaction('rw', ...)` so a failure between the delete and the put cannot drop the whole set, and rows written by the older ID format cannot linger
- New `summarizeFanOut` + `logFanOut` diagnostic reports fan-out width to the EPG debug log

## On the fan-out diagnostic

Every extra stream behind an XMLTV channel multiplies rows in the `programs` table. A provider shipping a junk or over-shared `epg_channel_id` could therefore balloon storage. This logs the shape rather than capping it: a hard cap would silently withhold EPG from legitimately-large variant groups. Observe first, cap later only if real data warrants it.

## Deltas from #88

- Atomic transaction around the mapping delete + put (was two bare awaits)
- Fan-out extracted to a pure, tested helper (was inline in `sync.ts` and untested - the riskiest change had zero coverage)
- Fan-out diagnostic added
- Removed the now-stale `EpgMapping` import from `sync.ts`
- Targets `dev` rather than `main`

## Validation

- `pnpm -r typecheck` clean (5 projects)
- `pnpm --filter @sbtltv/ui test` - 19 files, 148 tests pass (baseline 138, +10 new)
- Not yet device-tested against a real provider - see the fan-out log line

Fixes #87
