### PR TITLE
ci: bump workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'pnpm'
@@ -98,7 +98,7 @@ jobs:
       # Upload full app artifacts
       - name: Upload app (Windows)
         if: matrix.platform == 'win'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbtlTV-win-native
           path: release/*.exe
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload app (macOS)
         if: matrix.platform == 'mac'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbtlTV-mac-native
           path: release/*.dmg
@@ -115,7 +115,7 @@ jobs:
       # Also upload just the native addon for debugging
       - name: Upload native addon (Windows)
         if: matrix.platform == 'win'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mpv-texture-win
           path: |
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload native addon (macOS)
         if: matrix.platform == 'mac'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mpv-texture-mac
           path: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'pnpm'
@@ -90,7 +90,7 @@ jobs:
 
       # Upload artifacts (mirrors release.yml artifact set)
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbtlTV-${{ matrix.platform }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'pnpm'
@@ -82,7 +82,7 @@ jobs:
           APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-${{ matrix.platform }}
           path: |
@@ -103,10 +103,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Silences the Node 20 deprecation warning (GitHub is force-running the v4 actions on Node 24 already; this makes it explicit before Node 20 is removed).

Bumped to the **first node24 major** of each (minimal breaking-change surface; each verified via its action.yml `runs.using`):

| action | was | now | runtime |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24 |
| actions/setup-node | v4 | v5 | node24 |
| actions/upload-artifact | v4 | v6 | node24 |
| actions/download-artifact | v4 | v7 | node24 |
| pnpm/action-setup | v4 | v6 | node24 |

Note: `v5` of upload/download-artifact is still node20, so those needed v6/v7. upload-artifact@v6 and download-artifact@v7 are both v4+ backend and cross-compatible.

## Validation
- A build-test.yml run is dispatched on this branch (exercises checkout/setup-node/pnpm/upload-artifact on all 3 platforms).
- **Not fully exercised until a real release:** release.yml's upload -> download-artifact round-trip in the `release` job. Suggest confirming the next release publishes 10 assets as usual before relying on it.

Do not merge until the build-test run is green.