### PR TITLE
Render mpv video inside Electron with DMA-BUF

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,12 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      - name: Install native build dependencies (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libmpv-dev libegl1-mesa-dev libgbm-dev libdrm-dev libgl-dev pkg-config
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -64,8 +70,8 @@ jobs:
       - name: Build all packages
         run: pnpm build
 
-      - name: Build native addon (macOS only)
-        if: matrix.platform == 'mac'
+      - name: Build native addon
+        if: matrix.platform == 'mac' || matrix.platform == 'linux'
         run: |
           cd packages/mpv-texture
           npm run build:native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      - name: Install native build dependencies (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libmpv-dev libegl1-mesa-dev libgbm-dev libdrm-dev libgl-dev pkg-config
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -58,8 +64,8 @@ jobs:
       - name: Build all packages
         run: pnpm build
 
-      - name: Build native addon (macOS only)
-        if: matrix.platform == 'mac'
+      - name: Build native addon
+        if: matrix.platform == 'mac' || matrix.platform == 'linux'
         run: |
           cd packages/mpv-texture
           npm run build:native

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ A desktop IPTV player built with Electron and mpv.
 
 Download the latest release from the [Releases](../../releases) page:
 
-| Platform | Notes |
-|----------|-------|
-| Windows | mpv included |
-| Linux | Requires mpv installed separately |
+| Platform              | Notes                                                                      |
+| --------------------- | -------------------------------------------------------------------------- |
+| Windows               | mpv included                                                               |
+| Linux                 | Requires mpv installed separately                                          |
 | macOS (Apple Silicon) | Video renders natively in-window; mpv via Homebrew recommended as fallback |
 
 ### Windows Users
@@ -115,11 +115,12 @@ pnpm dist:linux
 Movie and series metadata comes from [The Movie Database](https://www.themoviedb.org/). Basic matching works automatically.
 
 For genre browsing and suggested/popular lists, add a TMDB Access Token:
+
 1. Create an account at [themoviedb.org](https://www.themoviedb.org/signup)
 2. Get an API Read Access Token from [API settings](https://www.themoviedb.org/settings/api)
 3. Add it in Settings → TMDB
 
-*This product uses the TMDB API but is not endorsed or certified by TMDB.*
+_This product uses the TMDB API but is not endorsed or certified by TMDB._
 
 ### Poster Overlays (RPDB)
 

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -98,6 +98,27 @@ linux:
   icon: assets/512x512.png
   category: AudioVideo
   artifactName: ${productName}-${version}-linux-${arch}.${ext}
+  extraResources:
+    - from: ../mpv-texture/build/Release/mpv_texture.node
+      to: mpv/mpv_texture.node
+
+deb:
+  depends:
+    - libgtk-3-0
+    - libnotify4
+    - libnss3
+    - libxss1
+    - libxtst6
+    - xdg-utils
+    - libatspi2.0-0
+    - libuuid1
+    - libsecret-1-0
+    - mpv
+    - libmpv2
+    - libegl1
+    - libgbm1
+    - libdrm2
+    - libgl1
 
 appImage:
   license: ../../LICENSE

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -14,7 +14,7 @@
     "build": "tsc",
     "dev": "electron . --dev",
     "start": "electron .",
-    "test": "tsc && node --test dist/gpu-selection.test.js",
+    "test": "tsc && node --test dist/gpu-selection.test.js dist/preload-shared-texture.test.js",
     "typecheck": "tsc --noEmit",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -14,6 +14,7 @@
     "build": "tsc",
     "dev": "electron . --dev",
     "start": "electron .",
+    "test": "tsc && node --test dist/gpu-selection.test.js",
     "typecheck": "tsc --noEmit",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",

--- a/packages/electron/src/gpu-selection.test.ts
+++ b/packages/electron/src/gpu-selection.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { selectChromiumGpuIdentity } from './gpu-selection.js';
+
+const hybridDevices = [
+  { active: true, vendorId: 0x1002, deviceId: 0x13c0 },
+  { active: false, vendorId: 0x10de, deviceId: 0x2f04 },
+];
+
+test('selects the GPU used by the high-performance WebGL consumer', () => {
+  assert.deepEqual(
+    selectChromiumGpuIdentity(hybridDevices, {
+      vendor: 'Google Inc. (NVIDIA Corporation)',
+      renderer: 'ANGLE (NVIDIA Corporation, NVIDIA GeForce RTX)',
+    }),
+    { vendorId: 0x10de, deviceId: 0x2f04, source: 'webgl' }
+  );
+});
+
+test('falls back to Chromium active GPU when WebGL vendor is unavailable', () => {
+  assert.deepEqual(
+    selectChromiumGpuIdentity(hybridDevices, null),
+    { vendorId: 0x1002, deviceId: 0x13c0, source: 'active' }
+  );
+});
+
+test('accepts hexadecimal GPU IDs returned as strings', () => {
+  assert.deepEqual(
+    selectChromiumGpuIdentity(
+      [{ active: true, vendorId: '0x8086', deviceId: '0x1234' }],
+      { vendor: 'Intel Inc.', renderer: 'Mesa Intel Graphics' }
+    ),
+    { vendorId: 0x8086, deviceId: 0x1234, source: 'webgl' }
+  );
+});

--- a/packages/electron/src/gpu-selection.ts
+++ b/packages/electron/src/gpu-selection.ts
@@ -1,0 +1,63 @@
+export interface GpuIdentity {
+  vendorId?: number;
+  deviceId?: number;
+  source: 'webgl' | 'active' | 'first' | 'none';
+}
+
+interface NormalizedGpuDevice {
+  active: boolean;
+  vendorId?: number;
+  deviceId?: number;
+}
+
+function parseGpuId(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value;
+  if (typeof value !== 'string') return undefined;
+  const parsed = Number.parseInt(value, value.startsWith('0x') ? 16 : 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function normalizeDevices(value: unknown): NormalizedGpuDevice[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((device) => {
+    if (!device || typeof device !== 'object') return [];
+    const record = device as Record<string, unknown>;
+    return [{
+      active: record.active === true,
+      vendorId: parseGpuId(record.vendorId),
+      deviceId: parseGpuId(record.deviceId),
+    }];
+  });
+}
+
+function inferWebGlVendorId(value: unknown): number | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const renderer = value as Record<string, unknown>;
+  const description = [renderer.vendor, renderer.renderer]
+    .filter((part): part is string => typeof part === 'string')
+    .join(' ')
+    .toLowerCase();
+
+  if (description.includes('nvidia')) return 0x10de;
+  if (description.includes('amd') || description.includes('ati') || description.includes('advanced micro devices')) {
+    return 0x1002;
+  }
+  if (description.includes('intel')) return 0x8086;
+  return undefined;
+}
+
+export function selectChromiumGpuIdentity(devicesValue: unknown, webGlRenderer: unknown): GpuIdentity {
+  const devices = normalizeDevices(devicesValue);
+  const webGlVendorId = inferWebGlVendorId(webGlRenderer);
+  const webGlDevice = webGlVendorId === undefined
+    ? undefined
+    : devices.find((device) => device.vendorId === webGlVendorId);
+  const selected = webGlDevice ?? devices.find((device) => device.active) ?? devices[0];
+
+  if (!selected) return { source: 'none' };
+  return {
+    vendorId: selected.vendorId,
+    deviceId: selected.deviceId,
+    source: webGlDevice ? 'webgl' : selected.active ? 'active' : 'first',
+  };
+}

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, net as electronNet, dialog, shell, powerSaveBlocker, powerMonitor } from 'electron';
+import { app, BrowserWindow, ipcMain, net as electronNet, dialog, shell, powerSaveBlocker, powerMonitor, safeStorage } from 'electron';
 import * as path from 'path';
 import { spawn, ChildProcess, execFileSync } from 'child_process';
 import * as net from 'net';
@@ -12,8 +12,10 @@ type UpdateInfo = electronUpdater.UpdateInfo;
 // Dynamic import - mpv-texture-bridge depends on Electron's sharedTexture API
 // which may not be available on all platforms
 type MpvTextureBridgeType = import('./mpv-texture-bridge.js').MpvTextureBridge;
+const MPV_COMPATIBILITY_ARG = '--mpv-compatibility-mode';
+const compatibilityModeRequested = process.platform === 'linux' && process.argv.includes(MPV_COMPATIBILITY_ARG);
 let MpvTextureBridgeClass: (new () => MpvTextureBridgeType) | null = null;
-if (process.platform === 'darwin') {
+if (process.platform === 'darwin' || (process.platform === 'linux' && !compatibilityModeRequested)) {
   try {
     const mod = await import('./mpv-texture-bridge.js');
     MpvTextureBridgeClass = mod.MpvTextureBridge;
@@ -22,9 +24,9 @@ if (process.platform === 'darwin') {
   }
 }
 
-// On macOS, default to native mpv-texture addon (IOSurface shared texture).
+// macOS and Linux default to the native mpv-texture addon.
 // Falls back to external mpv process if the bridge fails to load or initialize.
-const USE_NATIVE_MPV = process.platform === 'darwin';
+const USE_NATIVE_MPV = process.platform === 'darwin' || (process.platform === 'linux' && !compatibilityModeRequested);
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -73,6 +75,13 @@ const mpvState: MpvState = {
 // Generation counter prevents stale seeks on rapid re-load.
 let pendingResume: { position: number; generation: number } | null = null;
 let loadGeneration = 0;
+let currentMedia: { url: string; startPosition: number } | null = null;
+let pipelineFailurePromptOpen = false;
+
+interface CompatibilityHandoff {
+  url: string;
+  position: number;
+}
 
 // Prevent screen sleep during playback
 let sleepBlockerId: number | null = null;
@@ -167,6 +176,81 @@ function debugLog(message: string, category = 'app'): void {
     debugLogStream.write(line);
   } catch {
     // Silently fail - logging should never crash the app
+  }
+}
+
+function compatibilityHandoffPath(): string {
+  return path.join(app.getPath('sessionData'), 'mpv-compatibility-handoff.bin');
+}
+
+function saveCompatibilityHandoff(handoff: CompatibilityHandoff): boolean {
+  if (!safeStorage.isEncryptionAvailable()) {
+    debugLog('Skipping playback handoff because safeStorage is unavailable', 'mpv');
+    return false;
+  }
+
+  try {
+    const handoffPath = compatibilityHandoffPath();
+    fs.mkdirSync(path.dirname(handoffPath), { recursive: true });
+    const encrypted = safeStorage.encryptString(JSON.stringify(handoff));
+    fs.writeFileSync(handoffPath, encrypted, { mode: 0o600 });
+    fs.chmodSync(handoffPath, 0o600);
+    return true;
+  } catch (error) {
+    debugLog(`Could not save encrypted compatibility handoff: ${error instanceof Error ? error.message : error}`, 'mpv');
+    return false;
+  }
+}
+
+function consumeCompatibilityHandoff(): CompatibilityHandoff | null {
+  const handoffPath = compatibilityHandoffPath();
+  if (!fs.existsSync(handoffPath)) return null;
+
+  try {
+    if (!safeStorage.isEncryptionAvailable()) return null;
+    const decrypted = safeStorage.decryptString(fs.readFileSync(handoffPath));
+    const value: unknown = JSON.parse(decrypted);
+    if (!value || typeof value !== 'object') return null;
+    const candidate = value as Record<string, unknown>;
+    if (typeof candidate.url !== 'string' || typeof candidate.position !== 'number') return null;
+    return { url: candidate.url, position: Math.max(0, candidate.position) };
+  } catch (error) {
+    debugLog(`Could not consume compatibility handoff: ${error instanceof Error ? error.message : error}`, 'mpv');
+    return null;
+  } finally {
+    try { fs.unlinkSync(handoffPath); } catch { /* Already removed or inaccessible. */ }
+  }
+}
+
+function discardStaleCompatibilityHandoff(): void {
+  try { fs.unlinkSync(compatibilityHandoffPath()); } catch { /* No stale handoff. */ }
+}
+
+function parseGpuId(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value;
+  if (typeof value !== 'string') return undefined;
+  const parsed = Number.parseInt(value, value.startsWith('0x') ? 16 : 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+async function getChromiumGpuIdentity(): Promise<{ vendorId?: number; deviceId?: number }> {
+  try {
+    const info: unknown = await app.getGPUInfo('basic');
+    if (!info || typeof info !== 'object') return {};
+    const devices = (info as Record<string, unknown>).gpuDevice;
+    if (!Array.isArray(devices)) return {};
+
+    const active = devices.find((device) => device && typeof device === 'object' && (device as Record<string, unknown>).active === true)
+      ?? devices[0];
+    if (!active || typeof active !== 'object') return {};
+    const gpu = active as Record<string, unknown>;
+    return {
+      vendorId: parseGpuId(gpu.vendorId),
+      deviceId: parseGpuId(gpu.deviceId),
+    };
+  } catch (error) {
+    debugLog(`Could not read Chromium GPU identity: ${error instanceof Error ? error.message : error}`, 'mpv');
+    return {};
   }
 }
 
@@ -556,9 +640,20 @@ async function initNativeMpv(): Promise<boolean> {
 
   let bridge: MpvTextureBridgeType | null = null;
   try {
+    const gpu = process.platform === 'linux' ? await getChromiumGpuIdentity() : {};
+    if (gpu.vendorId !== undefined) {
+      debugLog(
+        `Chromium GPU vendor=0x${gpu.vendorId.toString(16)} device=${gpu.deviceId !== undefined ? `0x${gpu.deviceId.toString(16)}` : 'unknown'}`,
+        'mpv'
+      );
+    }
     bridge = new MpvTextureBridgeClass();
     const success = await bridge.initialize(mainWindow, {
       hwdec: 'auto',
+      gpuVendorId: gpu.vendorId,
+      gpuDeviceId: gpu.deviceId,
+      debugLogging: debugLoggingEnabled,
+      finishBeforeExport: process.env.SBTLTV_MPV_GL_FINISH === '1',
     });
 
     if (!success) {
@@ -603,6 +698,10 @@ async function initNativeMpv(): Promise<boolean> {
       sendToRenderer('mpv-error', error);
     });
 
+    bridge.onPipelineFailure((error) => {
+      void handleNativePipelineFailure(error);
+    });
+
     console.log('[mpv] Native mpv-texture bridge initialized');
     debugLog('Native mpv-texture bridge initialized', 'mpv');
     sendToRenderer('mpv-ready', true);
@@ -615,6 +714,57 @@ async function initNativeMpv(): Promise<boolean> {
     bridge?.destroy();
     return false;
   }
+}
+
+async function handleNativePipelineFailure(error: string): Promise<void> {
+  if (process.platform !== 'linux' || pipelineFailurePromptOpen || !mainWindow) return;
+  pipelineFailurePromptOpen = true;
+  const failurePosition = mpvState.position > 0 ? mpvState.position : currentMedia?.startPosition ?? 0;
+  mpvBridge?.stop();
+  debugLog(error, 'mpv');
+
+  try {
+    const result = await dialog.showMessageBox(mainWindow, {
+      type: 'error',
+      title: 'Native video playback failed',
+      message: 'The native Linux video pipeline stopped working.',
+      detail: 'Restart sbtlTV in floating-window compatibility mode for this launch?',
+      buttons: ['Restart in Compatibility Mode', 'Cancel'],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+    });
+
+    if (result.response !== 0) return;
+
+    if (currentMedia) {
+      saveCompatibilityHandoff({
+        url: currentMedia.url,
+        position: failurePosition,
+      });
+    }
+
+    const relaunchArgs = process.argv.slice(1).filter((argument) => argument !== MPV_COMPATIBILITY_ARG);
+    app.relaunch({ args: [...relaunchArgs, MPV_COMPATIBILITY_ARG] });
+    app.exit(0);
+  } finally {
+    pipelineFailurePromptOpen = false;
+  }
+}
+
+async function confirmCompatibilityFallback(): Promise<boolean> {
+  if (process.platform !== 'linux' || !mainWindow) return true;
+  const result = await dialog.showMessageBox(mainWindow, {
+    type: 'warning',
+    title: 'Native video playback unavailable',
+    message: 'sbtlTV could not start the native Linux video pipeline.',
+    detail: 'Use floating-window compatibility mode for this launch?',
+    buttons: ['Use Compatibility Mode', 'Quit'],
+    defaultId: 0,
+    cancelId: 1,
+    noLink: true,
+  });
+  return result.response === 0;
 }
 
 async function connectToMpvSocket(): Promise<void> {
@@ -801,10 +951,10 @@ ipcMain.handle('window-set-fullscreen', () => {
   }
 });
 
-// IPC Handlers - mpv control
-ipcMain.handle('mpv-load', async (_event, url: string, startPosition?: number) => {
+async function loadMedia(url: string, startPosition?: number): Promise<{ success?: boolean; error?: string }> {
   const resumeAt = startPosition && startPosition > 0 ? Math.floor(startPosition) : 0;
-  debugLog(`mpv-load called with URL: ${url}${resumeAt ? ` (resume @ ${resumeAt}s)` : ''}`, 'mpv');
+  currentMedia = { url, startPosition: resumeAt };
+  debugLog(`mpv-load called${resumeAt ? ` (resume @ ${resumeAt}s)` : ''}`, 'mpv');
 
   // Set pending resume — will seek when duration property arrives (file loaded).
   // Generation counter ensures stale seeks from previous loads are discarded.
@@ -844,6 +994,11 @@ ipcMain.handle('mpv-load', async (_event, url: string, startPosition?: number) =
     debugLog(`mpv-load FAILED: ${errMsg}`, 'mpv');
     return { error: errMsg };
   }
+}
+
+// IPC Handlers - mpv control
+ipcMain.handle('mpv-load', async (_event, url: string, startPosition?: number) => {
+  return loadMedia(url, startPosition);
 });
 
 ipcMain.handle('mpv-play', async () => {
@@ -968,6 +1123,7 @@ ipcMain.handle('mpv-seek', async (_event, seconds: number) => {
 ipcMain.handle('mpv-stop', async () => {
   debugLog('mpv-stop called', 'mpv');
   pendingResume = null;
+  currentMedia = null;
   if (useNativeMpv && mpvBridge) {
     try {
       mpvBridge.stop();
@@ -1450,17 +1606,26 @@ app.whenReady().then(async () => {
   // Initialize debug logging from saved settings
   const settings = storage.getSettings();
   initDebugLogging(settings.debugLoggingEnabled ?? false);
+  let compatibilityHandoff: CompatibilityHandoff | null = null;
+  if (compatibilityModeRequested) compatibilityHandoff = consumeCompatibilityHandoff();
+  else discardStaleCompatibilityHandoff();
 
   await createWindow();
 
-  // Try native mpv-texture if on macOS and bridge loaded
-  if (USE_NATIVE_MPV && MpvTextureBridgeClass) {
-    console.log('[mpv] Attempting native mpv-texture initialization...');
-    const nativeSuccess = await initNativeMpv();
+  if (USE_NATIVE_MPV) {
+    let nativeSuccess = false;
+    if (MpvTextureBridgeClass) {
+      console.log('[mpv] Attempting native mpv-texture initialization...');
+      nativeSuccess = await initNativeMpv();
+    }
     if (nativeSuccess) {
       console.log('[mpv] Using native mpv-texture bridge');
     } else {
-      console.log('[mpv] Native bridge failed, falling back to external mpv');
+      console.log('[mpv] Native bridge unavailable');
+      if (!await confirmCompatibilityFallback()) {
+        app.quit();
+        return;
+      }
       const mpvAvailable = await checkMpvAvailable();
       if (!mpvAvailable) {
         app.quit();
@@ -1469,13 +1634,18 @@ app.whenReady().then(async () => {
       await initMpv();
     }
   } else {
-    // Non-macOS or addon not loaded: use external mpv
+    // Windows and explicitly requested Linux compatibility launches use external mpv.
     const mpvAvailable = await checkMpvAvailable();
     if (!mpvAvailable) {
       app.quit();
       return;
     }
     await initMpv();
+  }
+
+  if (compatibilityHandoff) {
+    const result = await loadMedia(compatibilityHandoff.url, compatibilityHandoff.position);
+    if (result.error) sendToRenderer('mpv-error', 'Could not restore playback after compatibility restart.');
   }
 
   // Auto-updater (packaged builds with native update support:

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import type { Source } from '@sbtltv/core';
 import * as storage from './storage.js';
 import electronUpdater from 'electron-updater';
+import { selectChromiumGpuIdentity } from './gpu-selection.js';
 const { autoUpdater } = electronUpdater;
 type UpdateInfo = electronUpdater.UpdateInfo;
 // Dynamic import - mpv-texture-bridge depends on Electron's sharedTexture API
@@ -226,28 +227,38 @@ function discardStaleCompatibilityHandoff(): void {
   try { fs.unlinkSync(compatibilityHandoffPath()); } catch { /* No stale handoff. */ }
 }
 
-function parseGpuId(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value;
-  if (typeof value !== 'string') return undefined;
-  const parsed = Number.parseInt(value, value.startsWith('0x') ? 16 : 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+async function getHighPerformanceWebGlRenderer(): Promise<unknown> {
+  if (!mainWindow || mainWindow.isDestroyed()) return null;
+  try {
+    return await mainWindow.webContents.executeJavaScript(`(() => {
+      const canvas = document.createElement('canvas');
+      const gl = canvas.getContext('webgl2', { powerPreference: 'high-performance' });
+      if (!gl) return null;
+      const debugRenderer = gl.getExtension('WEBGL_debug_renderer_info');
+      if (!debugRenderer) return null;
+      const result = {
+        vendor: gl.getParameter(debugRenderer.UNMASKED_VENDOR_WEBGL),
+        renderer: gl.getParameter(debugRenderer.UNMASKED_RENDERER_WEBGL),
+      };
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+      return result;
+    })()`);
+  } catch (error) {
+    debugLog(`Could not read high-performance WebGL renderer: ${error instanceof Error ? error.message : error}`, 'mpv');
+    return null;
+  }
 }
 
 async function getChromiumGpuIdentity(): Promise<{ vendorId?: number; deviceId?: number }> {
   try {
+    const webGlRenderer = await getHighPerformanceWebGlRenderer();
     const info: unknown = await app.getGPUInfo('basic');
-    if (!info || typeof info !== 'object') return {};
-    const devices = (info as Record<string, unknown>).gpuDevice;
-    if (!Array.isArray(devices)) return {};
-
-    const active = devices.find((device) => device && typeof device === 'object' && (device as Record<string, unknown>).active === true)
-      ?? devices[0];
-    if (!active || typeof active !== 'object') return {};
-    const gpu = active as Record<string, unknown>;
-    return {
-      vendorId: parseGpuId(gpu.vendorId),
-      deviceId: parseGpuId(gpu.deviceId),
-    };
+    const devices = info && typeof info === 'object'
+      ? (info as Record<string, unknown>).gpuDevice
+      : undefined;
+    const gpu = selectChromiumGpuIdentity(devices, webGlRenderer);
+    debugLog(`GPU selection source=${gpu.source}`, 'mpv');
+    return gpu;
   } catch (error) {
     debugLog(`Could not read Chromium GPU identity: ${error instanceof Error ? error.message : error}`, 'mpv');
     return {};

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -713,6 +713,10 @@ async function initNativeMpv(): Promise<boolean> {
       void handleNativePipelineFailure(error);
     });
 
+    bridge.onDiagnostics((message) => {
+      debugLog(message, 'mpv-texture');
+    });
+
     console.log('[mpv] Native mpv-texture bridge initialized');
     debugLog('Native mpv-texture bridge initialized', 'mpv');
     sendToRenderer('mpv-ready', true);

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -945,7 +945,7 @@ ipcMain.handle('window-set-fullscreen', () => {
     // macOS: opaque window + native mpv texture — true OS fullscreen + enter/leave events work.
     mainWindow.setFullScreen(!mainWindow.isFullScreen());
   } else {
-    // Linux: separate mpv window; setFullScreen is unreliable, maximize is the working equivalent.
+    // Linux: maximize is the working fullscreen equivalent for the frameless Electron window.
     if (mainWindow.isMaximized()) mainWindow.unmaximize();
     else mainWindow.maximize();
   }

--- a/packages/electron/src/mpv-texture-bridge.ts
+++ b/packages/electron/src/mpv-texture-bridge.ts
@@ -73,15 +73,16 @@ export class MpvTextureBridge {
       this.initialized = true;
       console.log('[MpvTextureBridge] Initialized successfully');
 
-      // Log frame stats every 2 seconds
-      this.statsInterval = setInterval(() => {
-        if (this.stats.received > 0) {
-          const avgImport = this.stats.sendCount > 0 ? (this.stats.importMs / this.stats.sendCount).toFixed(1) : '?';
-          const avgSend = this.stats.sendCount > 0 ? (this.stats.sendMs / this.stats.sendCount).toFixed(1) : '?';
-          console.log(`[MpvTextureBridge] sent:${this.stats.sent}/2s drop:${this.stats.dropped} mpv:${this.stats.received} err:${this.stats.errors} | import:${avgImport}ms send:${avgSend}ms`);
-          this.stats = { received: 0, dropped: 0, sent: 0, errors: 0, importMs: 0, sendMs: 0, sendCount: 0 };
-        }
-      }, 2000);
+      if (config?.debugLogging) {
+        this.statsInterval = setInterval(() => {
+          if (this.stats.received > 0) {
+            const avgImport = this.stats.sendCount > 0 ? (this.stats.importMs / this.stats.sendCount).toFixed(1) : '?';
+            const avgSend = this.stats.sendCount > 0 ? (this.stats.sendMs / this.stats.sendCount).toFixed(1) : '?';
+            console.log(`[MpvTextureBridge] sent:${this.stats.sent}/2s drop:${this.stats.dropped} mpv:${this.stats.received} err:${this.stats.errors} | import:${avgImport}ms send:${avgSend}ms`);
+            this.stats = { received: 0, dropped: 0, sent: 0, errors: 0, importMs: 0, sendMs: 0, sendCount: 0 };
+          }
+        }, 2000);
+      }
 
       return true;
     } catch (error) {

--- a/packages/electron/src/mpv-texture-bridge.ts
+++ b/packages/electron/src/mpv-texture-bridge.ts
@@ -22,11 +22,24 @@ export class MpvTextureBridge {
   private statusCallback?: (status: MpvStatus) => void;
   private errorCallback?: (error: string) => void;
   private pipelineFailureCallback?: (error: string) => void;
+  private diagnosticsCallback?: (message: string) => void;
   private consecutiveErrors = 0;
   private pipelineFailureReported = false;
 
   // Diagnostics
-  private stats = { received: 0, dropped: 0, sent: 0, errors: 0, importMs: 0, sendMs: 0, sendCount: 0 };
+  private stats = {
+    received: 0,
+    dropped: 0,
+    sent: 0,
+    errors: 0,
+    importMs: 0,
+    sendMs: 0,
+    maxSendMs: 0,
+    releaseMs: 0,
+    maxReleaseMs: 0,
+    sendCount: 0,
+    releaseCount: 0,
+  };
   private statsInterval: ReturnType<typeof setInterval> | null = null;
 
   /**
@@ -73,16 +86,28 @@ export class MpvTextureBridge {
       this.initialized = true;
       console.log('[MpvTextureBridge] Initialized successfully');
 
-      if (config?.debugLogging) {
-        this.statsInterval = setInterval(() => {
-          if (this.stats.received > 0) {
-            const avgImport = this.stats.sendCount > 0 ? (this.stats.importMs / this.stats.sendCount).toFixed(1) : '?';
-            const avgSend = this.stats.sendCount > 0 ? (this.stats.sendMs / this.stats.sendCount).toFixed(1) : '?';
-            console.log(`[MpvTextureBridge] sent:${this.stats.sent}/2s drop:${this.stats.dropped} mpv:${this.stats.received} err:${this.stats.errors} | import:${avgImport}ms send:${avgSend}ms`);
-            this.stats = { received: 0, dropped: 0, sent: 0, errors: 0, importMs: 0, sendMs: 0, sendCount: 0 };
-          }
-        }, 2000);
-      }
+      this.statsInterval = setInterval(() => {
+        if (this.stats.received === 0) return;
+        const avgImport = this.stats.sendCount > 0 ? (this.stats.importMs / this.stats.sendCount).toFixed(1) : '?';
+        const avgSend = this.stats.sendCount > 0 ? (this.stats.sendMs / this.stats.sendCount).toFixed(1) : '?';
+        const avgRelease = this.stats.releaseCount > 0 ? (this.stats.releaseMs / this.stats.releaseCount).toFixed(1) : '?';
+        const message = `[MpvTextureBridge] sent:${this.stats.sent}/2s drop:${this.stats.dropped} mpv:${this.stats.received} err:${this.stats.errors} | import:${avgImport}ms send:${avgSend}/${this.stats.maxSendMs.toFixed(1)}ms release:${avgRelease}/${this.stats.maxReleaseMs.toFixed(1)}ms`;
+        console.log(message);
+        this.diagnosticsCallback?.(message);
+        this.stats = {
+          received: 0,
+          dropped: 0,
+          sent: 0,
+          errors: 0,
+          importMs: 0,
+          sendMs: 0,
+          maxSendMs: 0,
+          releaseMs: 0,
+          maxReleaseMs: 0,
+          sendCount: 0,
+          releaseCount: 0,
+        };
+      }, 2000);
 
       return true;
     } catch (error) {
@@ -134,6 +159,7 @@ export class MpvTextureBridge {
     try {
       if (!this.window || this.window.isDestroyed()) return;
       const frameOwner = this.mpv;
+      const frameStartedAt = performance.now();
       let sharedTextureHandle: SharedTextureHandle;
       if (textureInfo.kind === 'ioSurface') {
         const ioSurfaceBuffer = Buffer.alloc(8);
@@ -158,6 +184,10 @@ export class MpvTextureBridge {
         },
         ...(textureInfo.kind === 'nativePixmap' ? {
           allReferencesReleased: () => {
+            const releaseMs = performance.now() - frameStartedAt;
+            this.stats.releaseMs += releaseMs;
+            this.stats.maxReleaseMs = Math.max(this.stats.maxReleaseMs, releaseMs);
+            this.stats.releaseCount++;
             if (frameOwner?.isInitialized) frameOwner.releaseFrame(textureInfo.bufferId);
           },
         } : {}),
@@ -177,6 +207,7 @@ export class MpvTextureBridge {
       const t2 = performance.now();
       this.stats.importMs += t1 - t0;
       this.stats.sendMs += t2 - t1;
+      this.stats.maxSendMs = Math.max(this.stats.maxSendMs, t2 - t1);
       this.stats.sendCount++;
       this.stats.sent++;
       this.consecutiveErrors = 0;
@@ -278,6 +309,10 @@ export class MpvTextureBridge {
 
   onPipelineFailure(callback: (error: string) => void): void {
     this.pipelineFailureCallback = callback;
+  }
+
+  onDiagnostics(callback: (message: string) => void): void {
+    this.diagnosticsCallback = callback;
   }
 
   /**

--- a/packages/electron/src/mpv-texture-bridge.ts
+++ b/packages/electron/src/mpv-texture-bridge.ts
@@ -8,6 +8,16 @@
 import { BrowserWindow, sharedTexture, SharedTextureHandle } from 'electron';
 import type { MpvTexture, MpvStatus, TextureInfo, MpvConfig } from '@sbtltv/mpv-texture';
 
+interface QueuedFrame {
+  textureInfo: TextureInfo;
+  generation: number;
+}
+
+interface SharedTextureFrameMetadata {
+  generation: number;
+  index: number;
+}
+
 /**
  * MpvTextureBridge - Integrates mpv-texture with Electron's sharedTexture API
  */
@@ -18,7 +28,11 @@ export class MpvTextureBridge {
   private initialized = false;
   private activeSends = 0;
   private readonly maxConcurrentSends = 2;
-  private pendingFrame: TextureInfo | null = null;
+  private pendingFrame: QueuedFrame | null = null;
+  private frameGeneration = 0;
+  private outstandingTextureReferences = 0;
+  private destroyRequested = false;
+  private destroyFinalized = false;
   private statusCallback?: (status: MpvStatus) => void;
   private errorCallback?: (error: string) => void;
   private pipelineFailureCallback?: (error: string) => void;
@@ -123,29 +137,34 @@ export class MpvTextureBridge {
    * while both transfer slots are busy.
    */
   private handleFrame(textureInfo: TextureInfo): void {
-    if (!this.window || !this.mpv) {
+    if (this.destroyRequested || !this.window || !this.mpv) {
       this.releaseFrame(textureInfo);
       return;
     }
 
     this.stats.received++;
+    const frame = { textureInfo, generation: this.frameGeneration } satisfies QueuedFrame;
 
     if (this.activeSends >= this.maxConcurrentSends) {
       if (this.pendingFrame) {
         this.stats.dropped++;
-        this.releaseFrame(this.pendingFrame);
+        this.releaseFrame(this.pendingFrame.textureInfo);
       }
-      this.pendingFrame = textureInfo;
+      this.pendingFrame = frame;
       return;
     }
 
-    this.startSend(textureInfo);
+    this.startSend(frame);
   }
 
-  private startSend(textureInfo: TextureInfo): void {
+  private startSend(frame: QueuedFrame): void {
     this.activeSends++;
-    void this.sendFrame(textureInfo).finally(() => {
+    void this.sendFrame(frame).finally(() => {
       this.activeSends--;
+      if (this.destroyRequested) {
+        this.tryFinalizeDestroy();
+        return;
+      }
       if (!this.pendingFrame || this.activeSends >= this.maxConcurrentSends) return;
       const nextFrame = this.pendingFrame;
       this.pendingFrame = null;
@@ -153,13 +172,15 @@ export class MpvTextureBridge {
     });
   }
 
-  private async sendFrame(textureInfo: TextureInfo): Promise<void> {
+  private async sendFrame({ textureInfo, generation }: QueuedFrame): Promise<void> {
     let imported: ReturnType<typeof sharedTexture.importSharedTexture> | null = null;
     let releaseManagedByElectron = false;
     try {
-      if (!this.window || this.window.isDestroyed()) return;
+      const targetWindow = this.window;
+      if (this.destroyRequested || !targetWindow || targetWindow.isDestroyed()) return;
       const frameOwner = this.mpv;
       const frameStartedAt = performance.now();
+      let referencesReleased = false;
       let sharedTextureHandle: SharedTextureHandle;
       if (textureInfo.kind === 'ioSurface') {
         const ioSurfaceBuffer = Buffer.alloc(8);
@@ -182,26 +203,35 @@ export class MpvTextureBridge {
           visibleRect: { x: 0, y: 0, width: textureInfo.width, height: textureInfo.height },
           pixelFormat: textureInfo.format === 'nv12' ? 'rgba' : textureInfo.format,
         },
-        ...(textureInfo.kind === 'nativePixmap' ? {
-          allReferencesReleased: () => {
-            const releaseMs = performance.now() - frameStartedAt;
-            this.stats.releaseMs += releaseMs;
-            this.stats.maxReleaseMs = Math.max(this.stats.maxReleaseMs, releaseMs);
-            this.stats.releaseCount++;
-            if (frameOwner?.isInitialized) frameOwner.releaseFrame(textureInfo.bufferId);
-          },
-        } : {}),
+        allReferencesReleased: () => {
+          if (referencesReleased) return;
+          referencesReleased = true;
+          const releaseMs = performance.now() - frameStartedAt;
+          this.stats.releaseMs += releaseMs;
+          this.stats.maxReleaseMs = Math.max(this.stats.maxReleaseMs, releaseMs);
+          this.stats.releaseCount++;
+          if (textureInfo.kind === 'nativePixmap' && frameOwner?.isInitialized) {
+            frameOwner.releaseFrame(textureInfo.bufferId);
+          }
+          this.outstandingTextureReferences--;
+          this.tryFinalizeDestroy();
+        },
       });
+      this.outstandingTextureReferences++;
       releaseManagedByElectron = textureInfo.kind === 'nativePixmap';
 
       const t1 = performance.now();
 
+      const metadata = {
+        generation,
+        index: this.frameIndex++,
+      } satisfies SharedTextureFrameMetadata;
       await sharedTexture.sendSharedTexture(
         {
-          frame: this.window.webContents.mainFrame,
+          frame: targetWindow.webContents.mainFrame,
           importedSharedTexture: imported,
         },
-        this.frameIndex++
+        metadata
       );
 
       const t2 = performance.now();
@@ -235,11 +265,12 @@ export class MpvTextureBridge {
     if (!this.mpv || !this.initialized) {
       throw new Error('Bridge not initialized');
     }
-    // Clear stale frame in renderer and discard any queued frame
+    this.frameGeneration++;
+    // Clear stale frame in renderer and discard any queued frame.
     if (this.window && !this.window.isDestroyed()) {
-      this.window.webContents.send('video-clear');
+      this.window.webContents.send('video-clear', this.frameGeneration);
     }
-    if (this.pendingFrame) this.releaseFrame(this.pendingFrame);
+    if (this.pendingFrame) this.releaseFrame(this.pendingFrame.textureInfo);
     this.pendingFrame = null;
     return this.mpv.load(url, options);
   }
@@ -326,20 +357,34 @@ export class MpvTextureBridge {
    * Destroy and clean up
    */
   destroy(): void {
+    if (this.destroyFinalized) return;
+    if (this.destroyRequested) {
+      this.tryFinalizeDestroy();
+      return;
+    }
+    this.destroyRequested = true;
+    this.initialized = false;
     if (this.statsInterval) {
       clearInterval(this.statsInterval);
       this.statsInterval = null;
     }
     if (this.pendingFrame) {
-      this.releaseFrame(this.pendingFrame);
+      this.releaseFrame(this.pendingFrame.textureInfo);
       this.pendingFrame = null;
     }
-    if (this.mpv) {
-      this.mpv.destroy();
-      this.mpv = null;
-    }
+    if (this.mpv?.isInitialized) this.mpv.stop();
     this.window = null;
-    this.initialized = false;
+    this.tryFinalizeDestroy();
+  }
+
+  private tryFinalizeDestroy(): void {
+    if (this.destroyFinalized || !this.destroyRequested || this.activeSends > 0 || this.outstandingTextureReferences > 0) {
+      return;
+    }
+    this.destroyFinalized = true;
+    const mpv = this.mpv;
+    this.mpv = null;
+    if (mpv) mpv.destroy();
     console.log('[MpvTextureBridge] Destroyed');
   }
 

--- a/packages/electron/src/mpv-texture-bridge.ts
+++ b/packages/electron/src/mpv-texture-bridge.ts
@@ -16,11 +16,14 @@ export class MpvTextureBridge {
   private window: BrowserWindow | null = null;
   private frameIndex = 0;
   private initialized = false;
-  private sending = false;
+  private activeSends = 0;
+  private readonly maxConcurrentSends = 2;
   private pendingFrame: TextureInfo | null = null;
   private statusCallback?: (status: MpvStatus) => void;
   private errorCallback?: (error: string) => void;
+  private pipelineFailureCallback?: (error: string) => void;
   private consecutiveErrors = 0;
+  private pipelineFailureReported = false;
 
   // Diagnostics
   private stats = { received: 0, dropped: 0, sent: 0, errors: 0, importMs: 0, sendMs: 0, sendCount: 0 };
@@ -90,95 +93,107 @@ export class MpvTextureBridge {
   /**
    * Handle a new frame from mpv
    *
-   * Stores the latest frame and kicks off the send loop. If a send is already
-   * in progress, the frame is stored and will be picked up when the current
-   * send completes — always sending the most recent frame available.
+   * Keeps up to two transfers in flight. A single newest frame is retained
+   * while both transfer slots are busy.
    */
   private handleFrame(textureInfo: TextureInfo): void {
-    if (!this.window || !this.mpv) return;
+    if (!this.window || !this.mpv) {
+      this.releaseFrame(textureInfo);
+      return;
+    }
 
     this.stats.received++;
 
-    if (this.sending) {
-      // Store latest, overwriting any previously pending frame
-      this.stats.dropped++;
+    if (this.activeSends >= this.maxConcurrentSends) {
+      if (this.pendingFrame) {
+        this.stats.dropped++;
+        this.releaseFrame(this.pendingFrame);
+      }
+      this.pendingFrame = textureInfo;
+      return;
     }
-    this.pendingFrame = textureInfo;
 
-    if (!this.sending) {
-      this.sendLoop();
-    }
+    this.startSend(textureInfo);
   }
 
-  /**
-   * Send loop - keeps sending the latest pending frame until none remain.
-   * Only one instance runs at a time (guarded by this.sending).
-   */
-  private async sendLoop(): Promise<void> {
-    if (!this.window) return;
-    this.sending = true;
-
-    while (this.pendingFrame) {
-      const textureInfo = this.pendingFrame;
+  private startSend(textureInfo: TextureInfo): void {
+    this.activeSends++;
+    void this.sendFrame(textureInfo).finally(() => {
+      this.activeSends--;
+      if (!this.pendingFrame || this.activeSends >= this.maxConcurrentSends) return;
+      const nextFrame = this.pendingFrame;
       this.pendingFrame = null;
+      this.startSend(nextFrame);
+    });
+  }
 
-      let imported: ReturnType<typeof sharedTexture.importSharedTexture> | null = null;
-      try {
-        // Convert handle to platform format
-        let sharedTextureHandle: SharedTextureHandle;
-        if (process.platform === 'darwin') {
-          // handle contains the raw IOSurfaceRef pointer (8 bytes on arm64)
-          const ioSurfaceBuffer = Buffer.alloc(8);
-          ioSurfaceBuffer.writeBigUInt64LE(textureInfo.handle);
-          sharedTextureHandle = { ioSurface: ioSurfaceBuffer };
-        } else {
-          const handleBuffer = Buffer.alloc(8);
-          handleBuffer.writeBigUInt64LE(textureInfo.handle);
-          sharedTextureHandle = { ntHandle: handleBuffer };
-        }
-
-        const t0 = performance.now();
-
-        imported = sharedTexture.importSharedTexture({
-          textureInfo: {
-            handle: sharedTextureHandle,
-            codedSize: { width: textureInfo.width, height: textureInfo.height },
-            visibleRect: { x: 0, y: 0, width: textureInfo.width, height: textureInfo.height },
-            pixelFormat: textureInfo.format === 'nv12' ? 'rgba' : textureInfo.format,
-          },
-        });
-
-        const t1 = performance.now();
-
-        await sharedTexture.sendSharedTexture(
-          {
-            frame: this.window!.webContents.mainFrame,
-            importedSharedTexture: imported,
-          },
-          this.frameIndex++
-        );
-
-        const t2 = performance.now();
-        this.stats.importMs += t1 - t0;
-        this.stats.sendMs += t2 - t1;
-        this.stats.sendCount++;
-        this.stats.sent++;
-        this.consecutiveErrors = 0;
-      } catch (error) {
-        this.stats.errors++;
-        this.consecutiveErrors++;
-        if (this.consecutiveErrors === 1 || this.consecutiveErrors === 5) {
-          console.error(`[MpvTextureBridge] Frame error (${this.consecutiveErrors} consecutive):`, error);
-        }
-        if (this.consecutiveErrors === 5) {
-          this.errorCallback?.(`Shared texture pipeline failing: ${this.consecutiveErrors} consecutive frame errors`);
-        }
-      } finally {
-        imported?.release();
+  private async sendFrame(textureInfo: TextureInfo): Promise<void> {
+    let imported: ReturnType<typeof sharedTexture.importSharedTexture> | null = null;
+    let releaseManagedByElectron = false;
+    try {
+      if (!this.window || this.window.isDestroyed()) return;
+      const frameOwner = this.mpv;
+      let sharedTextureHandle: SharedTextureHandle;
+      if (textureInfo.kind === 'ioSurface') {
+        const ioSurfaceBuffer = Buffer.alloc(8);
+        ioSurfaceBuffer.writeBigUInt64LE(textureInfo.handle);
+        sharedTextureHandle = { ioSurface: ioSurfaceBuffer };
+      } else if (textureInfo.kind === 'ntHandle') {
+        const handleBuffer = Buffer.alloc(8);
+        handleBuffer.writeBigUInt64LE(textureInfo.handle);
+        sharedTextureHandle = { ntHandle: handleBuffer };
+      } else {
+        sharedTextureHandle = { nativePixmap: textureInfo.nativePixmap };
       }
-    }
 
-    this.sending = false;
+      const t0 = performance.now();
+
+      imported = sharedTexture.importSharedTexture({
+        textureInfo: {
+          handle: sharedTextureHandle,
+          codedSize: { width: textureInfo.width, height: textureInfo.height },
+          visibleRect: { x: 0, y: 0, width: textureInfo.width, height: textureInfo.height },
+          pixelFormat: textureInfo.format === 'nv12' ? 'rgba' : textureInfo.format,
+        },
+        ...(textureInfo.kind === 'nativePixmap' ? {
+          allReferencesReleased: () => {
+            if (frameOwner?.isInitialized) frameOwner.releaseFrame(textureInfo.bufferId);
+          },
+        } : {}),
+      });
+      releaseManagedByElectron = textureInfo.kind === 'nativePixmap';
+
+      const t1 = performance.now();
+
+      await sharedTexture.sendSharedTexture(
+        {
+          frame: this.window.webContents.mainFrame,
+          importedSharedTexture: imported,
+        },
+        this.frameIndex++
+      );
+
+      const t2 = performance.now();
+      this.stats.importMs += t1 - t0;
+      this.stats.sendMs += t2 - t1;
+      this.stats.sendCount++;
+      this.stats.sent++;
+      this.consecutiveErrors = 0;
+      this.pipelineFailureReported = false;
+    } catch (error) {
+      this.stats.errors++;
+      this.consecutiveErrors++;
+      if (this.consecutiveErrors === 1 || this.consecutiveErrors === 5) {
+        console.error(`[MpvTextureBridge] Frame error (${this.consecutiveErrors} consecutive):`, error);
+      }
+      if (this.consecutiveErrors >= 5 && !this.pipelineFailureReported) {
+        this.pipelineFailureReported = true;
+        this.pipelineFailureCallback?.(`Shared texture pipeline failed after ${this.consecutiveErrors} consecutive frame errors`);
+      }
+    } finally {
+      if (!releaseManagedByElectron) this.releaseFrame(textureInfo);
+      imported?.release();
+    }
   }
 
   /**
@@ -192,6 +207,7 @@ export class MpvTextureBridge {
     if (this.window && !this.window.isDestroyed()) {
       this.window.webContents.send('video-clear');
     }
+    if (this.pendingFrame) this.releaseFrame(this.pendingFrame);
     this.pendingFrame = null;
     return this.mpv.load(url, options);
   }
@@ -259,6 +275,10 @@ export class MpvTextureBridge {
     this.errorCallback = callback;
   }
 
+  onPipelineFailure(callback: (error: string) => void): void {
+    this.pipelineFailureCallback = callback;
+  }
+
   /**
    * Check if initialized
    */
@@ -274,6 +294,10 @@ export class MpvTextureBridge {
       clearInterval(this.statsInterval);
       this.statsInterval = null;
     }
+    if (this.pendingFrame) {
+      this.releaseFrame(this.pendingFrame);
+      this.pendingFrame = null;
+    }
     if (this.mpv) {
       this.mpv.destroy();
       this.mpv = null;
@@ -281,5 +305,11 @@ export class MpvTextureBridge {
     this.window = null;
     this.initialized = false;
     console.log('[MpvTextureBridge] Destroyed');
+  }
+
+  private releaseFrame(textureInfo: TextureInfo): void {
+    if (textureInfo.kind === 'nativePixmap') {
+      this.mpv?.releaseFrame(textureInfo.bufferId);
+    }
   }
 }

--- a/packages/electron/src/preload-shared-texture.test.ts
+++ b/packages/electron/src/preload-shared-texture.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import vm from 'node:vm';
+
+interface ImportedTextureStub {
+  getVideoFrame: () => VideoFrame;
+  release: () => void;
+}
+
+interface SharedTextureApiStub {
+  onFrame: (callback: (videoFrame: VideoFrame, index: number) => void) => void;
+  onClear: (callback: () => void) => void;
+}
+
+type SharedTextureReceiver = (
+  data: { importedSharedTexture: ImportedTextureStub },
+  metadata: unknown
+) => Promise<void>;
+
+function loadSandboxedPreload(): {
+  api: SharedTextureApiStub;
+  listeners: Map<string, (...args: unknown[]) => void>;
+  receiver: SharedTextureReceiver;
+} {
+  const preloadSource = readFileSync(new URL('./preload.cjs', import.meta.url), 'utf8');
+  const exposedApis = new Map<string, unknown>();
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  let receiver: SharedTextureReceiver | undefined;
+
+  const ipcRenderer = {
+    invoke: async () => undefined,
+    on: (channel: string, listener: (...args: unknown[]) => void) => listeners.set(channel, listener),
+    removeAllListeners: () => undefined,
+  };
+  const sharedTexture = {
+    setSharedTextureReceiver: (callback: SharedTextureReceiver) => {
+      receiver = callback;
+    },
+  };
+
+  vm.runInNewContext(preloadSource, {
+    console,
+    exports: {},
+    module: { exports: {} },
+    process: { argv: [], env: {}, platform: 'linux' },
+    require: (specifier: string) => {
+      if (specifier === 'electron/renderer') {
+        return {
+          contextBridge: {
+            exposeInMainWorld: (name: string, api: unknown) => exposedApis.set(name, api),
+          },
+          ipcRenderer,
+        };
+      }
+      if (specifier === 'electron') return { sharedTexture };
+      throw new Error(`Sandbox preload cannot require ${specifier}`);
+    },
+  });
+
+  const api = exposedApis.get('sharedTexture') as SharedTextureApiStub | undefined;
+  assert.ok(api);
+  assert.ok(receiver);
+  return { api, listeners, receiver };
+}
+
+test('sandboxed preload loads without local module dependencies', () => {
+  loadSandboxedPreload();
+});
+
+test('sandboxed preload rejects stale and out-of-order shared texture frames', async () => {
+  const { api, listeners, receiver } = loadSandboxedPreload();
+  const renderedIndices: number[] = [];
+  let clearCount = 0;
+  api.onFrame((_videoFrame, index) => renderedIndices.push(index));
+  api.onClear(() => clearCount++);
+
+  const clear = listeners.get('video-clear');
+  assert.ok(clear);
+  clear({}, 2);
+
+  const receive = async (generation: number, index: number) => {
+    let releaseCount = 0;
+    await receiver({
+      importedSharedTexture: {
+        getVideoFrame: () => ({}) as VideoFrame,
+        release: () => releaseCount++,
+      },
+    }, { generation, index });
+    assert.equal(releaseCount, 1);
+  };
+
+  await receive(1, 10);
+  await receive(2, 20);
+  await receive(2, 19);
+  await receive(3, 30);
+  clear({}, 3);
+
+  assert.deepEqual(renderedIndices, [20, 30]);
+  assert.equal(clearCount, 1);
+});

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron/renderer';
 import type { Source } from '@sbtltv/core';
 
 // Types for the exposed APIs
@@ -240,11 +240,10 @@ export interface SharedTextureApi {
   isAvailable: boolean;
 }
 
-// Check if sharedTexture API is available AND we're on a platform that uses native mpv.
-// Windows uses external mpv via --wid (renders behind the window), so the VideoCanvas
-// must not activate there — it would cover the external mpv output with a black canvas.
+// Check if sharedTexture is available on platforms that use native mpv. Windows
+// continues to render external mpv behind the BrowserWindow via --wid.
 let sharedTextureAvailable = false;
-if (process.platform === 'darwin') {
+if (process.platform === 'darwin' || process.platform === 'linux') {
   try {
     const { sharedTexture } = require('electron');
     sharedTextureAvailable = !!sharedTexture?.setSharedTextureReceiver;

--- a/packages/electron/src/preload.cts
+++ b/packages/electron/src/preload.cts
@@ -257,9 +257,48 @@ if (process.platform === 'darwin' || process.platform === 'linux') {
 let frameCallback: ((videoFrame: VideoFrame, index: number) => void) | null = null;
 let clearCallback: (() => void) | null = null;
 
+interface SharedTextureFrameMetadata {
+  generation: number;
+  index: number;
+}
+
+function isSharedTextureFrameMetadata(value: unknown): value is SharedTextureFrameMetadata {
+  if (!value || typeof value !== 'object') return false;
+  const metadata = value as Record<string, unknown>;
+  return typeof metadata.generation === 'number' && Number.isSafeInteger(metadata.generation) && metadata.generation >= 0 &&
+    typeof metadata.index === 'number' && Number.isSafeInteger(metadata.index) && metadata.index >= 0;
+}
+
+class SharedTextureFrameOrder {
+  private generation = 0;
+  private lastFrameIndex = -1;
+
+  shouldClear(generation: unknown): boolean {
+    if (!Number.isSafeInteger(generation) || Number(generation) < 0 || Number(generation) <= this.generation) {
+      return false;
+    }
+    this.generation = Number(generation);
+    this.lastFrameIndex = -1;
+    return true;
+  }
+
+  acceptFrame(metadata: SharedTextureFrameMetadata): boolean {
+    if (metadata.generation < this.generation) return false;
+    if (metadata.generation > this.generation) {
+      this.generation = metadata.generation;
+      this.lastFrameIndex = -1;
+    }
+    if (metadata.index <= this.lastFrameIndex) return false;
+    this.lastFrameIndex = metadata.index;
+    return true;
+  }
+}
+
+const sharedTextureFrameOrder = new SharedTextureFrameOrder();
+
 // Listen for clear signal from main process (content switch)
-ipcRenderer.on('video-clear', () => {
-  clearCallback?.();
+ipcRenderer.on('video-clear', (_event, generation: unknown) => {
+  if (sharedTextureFrameOrder.shouldClear(generation)) clearCallback?.();
 });
 
 // Set up frame receiver if available
@@ -267,14 +306,18 @@ if (sharedTextureAvailable) {
   try {
     const { sharedTexture } = require('electron');
     sharedTexture.setSharedTextureReceiver(async (data: { importedSharedTexture: { getVideoFrame: () => VideoFrame; release: () => void } }, ...args: unknown[]) => {
-      const index = typeof args[0] === 'number' ? args[0] : 0;
       const imported = data.importedSharedTexture;
       try {
+        const metadata = args[0];
+        if (!isSharedTextureFrameMetadata(metadata) || !sharedTextureFrameOrder.acceptFrame(metadata)) {
+          imported?.release();
+          return;
+        }
         if (frameCallback && imported) {
           const videoFrame = imported.getVideoFrame();
           // Don't close videoFrame here - VideoCanvas manages frame lifecycle via rAF
           // It will close the previous frame when a new one arrives
-          frameCallback(videoFrame, index);
+          frameCallback(videoFrame, metadata.index);
           imported.release();
         } else if (imported) {
           imported.release();

--- a/packages/mpv-texture/README.md
+++ b/packages/mpv-texture/README.md
@@ -11,8 +11,8 @@ Native N-API addon for GPU-accelerated video playback using libmpv with zero-cop
 └─────────────────┘     └──────────────────┘     └─────────────────┘
          │                       │                        │
          ▼                       ▼                        ▼
-    GPU Texture  ───▶  DXGI Handle (Win)  ───▶  VideoFrame  ───▶  WebGPU
-                       IOSurface (Mac)
+    GPU Texture  ───▶  IOSurface (Mac)   ───▶  VideoFrame  ───▶  WebGL
+                       DMA-BUF (Linux)
 ```
 
 ## Prerequisites
@@ -25,6 +25,11 @@ Native N-API addon for GPU-accelerated video playback using libmpv with zero-cop
 ### macOS
 - Xcode Command Line Tools
 - libmpv development files in `deps/mpv/macos/`
+- Node.js 18+
+
+### Linux
+- libmpv, EGL, GBM, libdrm, and OpenGL development packages
+- A DRM render node supported by the active graphics driver
 - Node.js 18+
 
 ## Building
@@ -158,18 +163,32 @@ Set callback for status changes.
 #### `onError(callback: ErrorCallback): void`
 Set callback for errors.
 
-#### `releaseFrame(): void`
-Release the current frame (call when Electron is done with texture).
+#### `releaseFrame(bufferId: number): void`
+Release the exact Linux DMA-BUF slot after Electron calls `allReferencesReleased`.
 
 ### TextureInfo
 
 ```typescript
-interface TextureInfo {
-  handle: bigint;           // Platform-specific handle
-  width: number;            // Texture width
-  height: number;           // Texture height
-  format: 'rgba' | 'nv12' | 'bgra';
-}
+type TextureInfo =
+  | {
+      kind: 'ioSurface';
+      handle: bigint;
+      width: number;
+      height: number;
+      format: 'rgba' | 'nv12' | 'bgra';
+    }
+  | {
+      kind: 'nativePixmap';
+      bufferId: number;
+      nativePixmap: {
+        planes: Array<{ fd: number; stride: number; offset: number; size: number }>;
+        modifier: string;
+        supportsZeroCopyWebGpuImport: false;
+      };
+      width: number;
+      height: number;
+      format: 'bgra';
+    };
 ```
 
 ### MpvStatus
@@ -189,10 +208,13 @@ interface MpvStatus {
 ## Platform Notes
 
 ### Windows
-Uses WGL_NV_DX_interop for OpenGL/D3D11 interop. Requires NVIDIA or AMD GPU with driver support.
+The app currently uses external mpv through `--wid`; the DXGI implementation remains reference code.
 
 ### macOS
 Uses IOSurface for texture sharing. Works with Metal/OpenGL.
+
+### Linux
+Uses EGL and GBM to render libmpv into DMA-BUF-backed textures imported through Electron NativePixmap handles. Runtime libmpv is supplied by the host system.
 
 ## Bundling libmpv
 

--- a/packages/mpv-texture/binding.gyp
+++ b/packages/mpv-texture/binding.gyp
@@ -14,6 +14,7 @@
         ["OS=='mac'", {
           "sources": [
             "src/native/addon.cpp",
+            "src/native/mpv_api.cpp",
             "src/native/mpv_context.cpp",
             "src/native/macos/iosurface_texture.mm"
           ],
@@ -48,6 +49,7 @@
         ["OS=='linux'", {
           "sources": [
             "src/native/addon.cpp",
+            "src/native/mpv_api.cpp",
             "src/native/mpv_context.cpp",
             "src/native/linux/egl_context.cpp",
             "src/native/linux/dmabuf_texture.cpp"
@@ -59,7 +61,7 @@
             "-std=c++17"
           ],
           "libraries": [
-            "<!@(pkg-config --libs mpv egl gbm libdrm gl)",
+            "<!@(pkg-config --libs egl gbm libdrm gl)",
             "-ldl"
           ]
         }],

--- a/packages/mpv-texture/binding.gyp
+++ b/packages/mpv-texture/binding.gyp
@@ -43,11 +43,29 @@
           ]
         }],
 
-        # ── Non-macOS: build a no-op stub (see src/native/stub.cpp for details) ──
-        # Windows uses external mpv via --wid flag, Linux uses separate window.
-        # The stub lets node-gyp and @electron/rebuild succeed without requiring
-        # mpv dev libraries on platforms that don't use the native addon.
-        ["OS!='mac'", {
+        # Linux: libmpv Render API -> EGL/GBM DMA-BUF -> Electron NativePixmap.
+        # Use system headers and libraries so the libmpv ABI matches the host.
+        ["OS=='linux'", {
+          "sources": [
+            "src/native/addon.cpp",
+            "src/native/mpv_context.cpp",
+            "src/native/linux/egl_context.cpp",
+            "src/native/linux/dmabuf_texture.cpp"
+          ],
+          "cflags": [
+            "<!@(pkg-config --cflags mpv egl gbm libdrm gl)"
+          ],
+          "cflags_cc": [
+            "-std=c++17"
+          ],
+          "libraries": [
+            "<!@(pkg-config --libs mpv egl gbm libdrm gl)",
+            "-ldl"
+          ]
+        }],
+
+        # Windows continues to use external mpv via --wid.
+        ["OS=='win'", {
           "sources": [
             "src/native/stub.cpp"
           ]

--- a/packages/mpv-texture/package.json
+++ b/packages/mpv-texture/package.json
@@ -7,8 +7,8 @@
   "private": true,
   "scripts": {
     "build": "npm run build:ts",
-    "//build:native": "Native addon only works on macOS (uses IOSurface). Windows/Linux use external mpv via --wid flag instead. Called explicitly in CI — NOT part of 'build' to prevent pnpm lifecycle from triggering node-gyp rebuild during electron-builder packaging (which nukes bundled dylibs).",
-    "build:native": "node -e \"process.platform === 'darwin' ? require('child_process').execSync('node-gyp rebuild', {stdio:'inherit'}) : console.log('[mpv-texture] Skipping native build — macOS only')\"",
+    "//build:native": "Builds the native addon on macOS and Linux. Called explicitly in CI and kept out of the normal build so electron-builder does not rebuild packaged native files.",
+    "build:native": "node -e \"['darwin', 'linux'].includes(process.platform) ? require('child_process').execSync('node-gyp rebuild', {stdio:'inherit'}) : console.log('[mpv-texture] Skipping native build on this platform')\"",
     "build:ts": "tsc",
     "clean": "node-gyp clean && rm -rf dist",
     "prepare": "npm run build:ts"

--- a/packages/mpv-texture/src/index.ts
+++ b/packages/mpv-texture/src/index.ts
@@ -59,19 +59,40 @@ console.log(`[mpv-texture] Loaded native addon from: ${loadedPath}`);
  */
 export type TextureFormat = 'rgba' | 'nv12' | 'bgra';
 
-/**
- * Information about an exported texture frame
- */
-export interface TextureInfo {
-  /** Platform-specific handle (HANDLE on Windows, IOSurfaceRef pointer on macOS) */
-  handle: bigint;
-  /** Texture width in pixels */
+interface TextureInfoBase {
   width: number;
-  /** Texture height in pixels */
   height: number;
-  /** Pixel format */
   format: TextureFormat;
 }
+
+export interface IOSurfaceTextureInfo extends TextureInfoBase {
+  kind: 'ioSurface';
+  handle: bigint;
+}
+
+export interface NTHandleTextureInfo extends TextureInfoBase {
+  kind: 'ntHandle';
+  handle: bigint;
+}
+
+export interface NativePixmapPlane {
+  fd: number;
+  stride: number;
+  offset: number;
+  size: number;
+}
+
+export interface NativePixmapTextureInfo extends TextureInfoBase {
+  kind: 'nativePixmap';
+  bufferId: number;
+  nativePixmap: {
+    planes: NativePixmapPlane[];
+    modifier: string;
+    supportsZeroCopyWebGpuImport: false;
+  };
+}
+
+export type TextureInfo = IOSurfaceTextureInfo | NTHandleTextureInfo | NativePixmapTextureInfo;
 
 /**
  * Playback status information
@@ -103,6 +124,14 @@ export interface MpvConfig {
   height?: number;
   /** Hardware decoding mode: 'auto', 'd3d11va', 'videotoolbox', etc. (default: 'auto') */
   hwdec?: string;
+  /** Chromium's active GPU PCI vendor ID */
+  gpuVendorId?: number;
+  /** Chromium's active GPU PCI device ID */
+  gpuDeviceId?: number;
+  /** Emit native GPU selection and DMA-BUF diagnostics */
+  debugLogging?: boolean;
+  /** Block for GPU completion before exporting each frame (diagnostic only) */
+  finishBeforeExport?: boolean;
 }
 
 /**
@@ -122,7 +151,7 @@ interface NativeAddon {
   onFrame(callback: (info: TextureInfo) => void): void;
   onStatus(callback: (status: MpvStatus) => void): void;
   onError(callback: (error: string) => void): void;
-  releaseFrame(): void;
+  releaseFrame(bufferId: number): void;
   isInitialized(): boolean;
 }
 
@@ -150,10 +179,14 @@ export type ErrorCallback = (error: string) => void;
  * mpv.create({ width: 1920, height: 1080, hwdec: 'auto' });
  *
  * mpv.onFrame((textureInfo) => {
- *   // Import texture via Electron's sharedTexture API
+ *   if (textureInfo.kind !== 'nativePixmap') return;
  *   const imported = sharedTexture.importSharedTexture({
- *     textureInfo,
- *     allReferenceReleased: () => mpv.releaseFrame()
+ *     textureInfo: {
+ *       handle: { nativePixmap: textureInfo.nativePixmap },
+ *       codedSize: { width: textureInfo.width, height: textureInfo.height },
+ *       pixelFormat: textureInfo.format,
+ *     },
+ *     allReferencesReleased: () => mpv.releaseFrame(textureInfo.bufferId)
  *   });
  *   sharedTexture.sendToRenderer(window.webContents, imported, frameIdx++);
  * });
@@ -311,14 +344,14 @@ export class MpvTexture {
   }
 
   /**
-   * Release the current frame
+   * Release an exported native buffer
    *
    * Must be called after Electron has finished using the texture
    * (in the allReferenceReleased callback of importSharedTexture).
    */
-  releaseFrame(): void {
+  releaseFrame(bufferId: number): void {
     if (this._initialized) {
-      addon.releaseFrame();
+      addon.releaseFrame(bufferId);
     }
   }
 

--- a/packages/mpv-texture/src/native/addon.cpp
+++ b/packages/mpv-texture/src/native/addon.cpp
@@ -98,25 +98,25 @@ Napi::Value Create(const Napi::CallbackInfo& info) {
     if (info.Length() > 0 && info[0].IsObject()) {
         auto configObj = info[0].As<Napi::Object>();
 
-        if (configObj.Has("width")) {
+        if (configObj.Has("width") && configObj.Get("width").IsNumber()) {
             config.width = configObj.Get("width").As<Napi::Number>().Uint32Value();
         }
-        if (configObj.Has("height")) {
+        if (configObj.Has("height") && configObj.Get("height").IsNumber()) {
             config.height = configObj.Get("height").As<Napi::Number>().Uint32Value();
         }
-        if (configObj.Has("hwdec")) {
+        if (configObj.Has("hwdec") && configObj.Get("hwdec").IsString()) {
             config.hwdec = configObj.Get("hwdec").As<Napi::String>().Utf8Value();
         }
-        if (configObj.Has("gpuVendorId")) {
+        if (configObj.Has("gpuVendorId") && configObj.Get("gpuVendorId").IsNumber()) {
             config.gpuVendorId = configObj.Get("gpuVendorId").As<Napi::Number>().Uint32Value();
         }
-        if (configObj.Has("gpuDeviceId")) {
+        if (configObj.Has("gpuDeviceId") && configObj.Get("gpuDeviceId").IsNumber()) {
             config.gpuDeviceId = configObj.Get("gpuDeviceId").As<Napi::Number>().Uint32Value();
         }
-        if (configObj.Has("debugLogging")) {
+        if (configObj.Has("debugLogging") && configObj.Get("debugLogging").IsBoolean()) {
             config.debugLogging = configObj.Get("debugLogging").As<Napi::Boolean>().Value();
         }
-        if (configObj.Has("finishBeforeExport")) {
+        if (configObj.Has("finishBeforeExport") && configObj.Get("finishBeforeExport").IsBoolean()) {
             config.finishBeforeExport = configObj.Get("finishBeforeExport").As<Napi::Boolean>().Value();
         }
     }

--- a/packages/mpv-texture/src/native/addon.cpp
+++ b/packages/mpv-texture/src/native/addon.cpp
@@ -27,9 +27,38 @@ static Napi::ThreadSafeFunction g_errorCallback;
 // Convert TextureInfo to JS object
 Napi::Object TextureInfoToJS(Napi::Env env, const TextureInfo& info) {
     auto obj = Napi::Object::New(env);
-    obj.Set("handle", Napi::BigInt::New(env, info.handle));
     obj.Set("width", Napi::Number::New(env, info.width));
     obj.Set("height", Napi::Number::New(env, info.height));
+
+    if (info.handle_type == TextureHandleType::NativePixmap) {
+        obj.Set("kind", Napi::String::New(env, "nativePixmap"));
+        obj.Set("bufferId", Napi::Number::New(env, info.buffer_id));
+
+        auto nativePixmap = Napi::Object::New(env);
+        auto planes = Napi::Array::New(env, info.planes.size());
+        for (size_t index = 0; index < info.planes.size(); index++) {
+            const auto& source = info.planes[index];
+            auto plane = Napi::Object::New(env);
+            plane.Set("fd", Napi::Number::New(env, source.fd));
+            plane.Set("stride", Napi::Number::New(env, source.stride));
+            plane.Set("offset", Napi::Number::New(env, source.offset));
+            plane.Set("size", Napi::Number::New(env, static_cast<double>(source.size)));
+            planes.Set(index, plane);
+        }
+        nativePixmap.Set("planes", planes);
+        nativePixmap.Set("modifier", Napi::String::New(env, info.modifier));
+        nativePixmap.Set(
+            "supportsZeroCopyWebGpuImport",
+            Napi::Boolean::New(env, info.supports_zero_copy_webgpu_import)
+        );
+        obj.Set("nativePixmap", nativePixmap);
+    } else {
+        obj.Set(
+            "kind",
+            Napi::String::New(env, info.handle_type == TextureHandleType::NTHandle ? "ntHandle" : "ioSurface")
+        );
+        obj.Set("handle", Napi::BigInt::New(env, info.handle));
+    }
 
     const char* formatStr = "rgba";
     switch (info.format) {
@@ -77,6 +106,18 @@ Napi::Value Create(const Napi::CallbackInfo& info) {
         }
         if (configObj.Has("hwdec")) {
             config.hwdec = configObj.Get("hwdec").As<Napi::String>().Utf8Value();
+        }
+        if (configObj.Has("gpuVendorId")) {
+            config.gpuVendorId = configObj.Get("gpuVendorId").As<Napi::Number>().Uint32Value();
+        }
+        if (configObj.Has("gpuDeviceId")) {
+            config.gpuDeviceId = configObj.Get("gpuDeviceId").As<Napi::Number>().Uint32Value();
+        }
+        if (configObj.Has("debugLogging")) {
+            config.debugLogging = configObj.Get("debugLogging").As<Napi::Boolean>().Value();
+        }
+        if (configObj.Has("finishBeforeExport")) {
+            config.finishBeforeExport = configObj.Get("finishBeforeExport").As<Napi::Boolean>().Value();
         }
     }
 
@@ -346,7 +387,11 @@ Napi::Value OnError(const Napi::CallbackInfo& info) {
 // Release current frame
 Napi::Value ReleaseFrame(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    if (g_context) g_context->releaseFrame();
+    if (info.Length() < 1 || !info[0].IsNumber()) {
+        Napi::TypeError::New(env, "bufferId number required").ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    if (g_context) g_context->releaseFrame(info[0].As<Napi::Number>().Uint32Value());
     return env.Undefined();
 }
 

--- a/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
+++ b/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
@@ -217,8 +217,10 @@ private:
             }
         }
 
-        std::cout << "[LinuxDmaBuf] Created " << buffer_count << " buffers "
-                  << width << "x" << height << " on " << m_context->renderNode() << std::endl;
+        if (m_context->debugLogging()) {
+            std::cout << "[LinuxDmaBuf] Created " << buffer_count << " buffers "
+                      << width << "x" << height << " on " << m_context->renderNode() << std::endl;
+        }
         return pool;
     }
 

--- a/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
+++ b/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
@@ -21,7 +21,7 @@ namespace mpv_texture {
 
 namespace {
 
-constexpr size_t buffer_count = 3;
+constexpr size_t buffer_count = 4;
 
 enum class SlotState {
     Free,

--- a/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
+++ b/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
@@ -1,0 +1,385 @@
+#ifdef __linux__
+
+#include "../texture_share.h"
+#include "egl_context.h"
+
+#define GL_GLEXT_PROTOTYPES
+#include <EGL/eglext.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <drm_fourcc.h>
+#include <gbm.h>
+#include <unistd.h>
+
+#include <array>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace mpv_texture {
+
+namespace {
+
+constexpr size_t buffer_count = 3;
+
+enum class SlotState {
+    Free,
+    Writing,
+    Exported
+};
+
+struct DmaBufSlot {
+    uint32_t id = 0;
+    gbm_bo* bo = nullptr;
+    EGLImageKHR image = EGL_NO_IMAGE_KHR;
+    GLuint texture = 0;
+    GLuint fbo = 0;
+    uint64_t modifier = DRM_FORMAT_MOD_INVALID;
+    std::vector<NativePixmapPlane> planes;
+    SlotState state = SlotState::Free;
+};
+
+struct DmaBufPool {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    std::array<DmaBufSlot, buffer_count> slots;
+};
+
+bool allSlotsReleased(const DmaBufPool& pool) {
+    for (const auto& slot : pool.slots) {
+        if (slot.state != SlotState::Free) return false;
+    }
+    return true;
+}
+
+uint64_t planeSize(int fd, uint32_t stride, uint32_t height) {
+    const off_t size = lseek(fd, 0, SEEK_END);
+    if (size > 0) {
+        lseek(fd, 0, SEEK_SET);
+        return static_cast<uint64_t>(size);
+    }
+    return static_cast<uint64_t>(stride) * height;
+}
+
+} // namespace
+
+class LinuxDmaBufTextureShare final : public ITextureShare {
+public:
+    ~LinuxDmaBufTextureShare() override { destroy(); }
+
+    bool initialize(void* gl_context) override {
+        m_context = static_cast<LinuxEglContext*>(gl_context);
+        if (!m_context || !m_context->gbmDevice()) return false;
+
+        m_createImage = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
+            m_context->getProcAddress("eglCreateImageKHR")
+        );
+        m_destroyImage = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(
+            m_context->getProcAddress("eglDestroyImageKHR")
+        );
+        m_imageTargetTexture = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(
+            m_context->getProcAddress("glEGLImageTargetTexture2DOES")
+        );
+        return m_createImage && m_destroyImage && m_imageTargetTexture;
+    }
+
+    bool createTexture(uint32_t width, uint32_t height) override {
+        auto pool = createPool(width, height);
+        if (!pool) return false;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_activePool = std::move(pool);
+        return true;
+    }
+
+    bool resizeTexture(uint32_t width, uint32_t height) override {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_activePool && m_activePool->width == width && m_activePool->height == height) {
+                return true;
+            }
+        }
+
+        // Allocate first so a failed resize leaves the current render target intact.
+        auto replacement = createPool(width, height);
+        if (!replacement) return false;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_activePool) m_retiredPools.push_back(std::move(m_activePool));
+        m_activePool = std::move(replacement);
+        cleanupRetiredPoolsLocked();
+        return true;
+    }
+
+    bool acquireRenderTarget(RenderTarget& target) override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        cleanupRetiredPoolsLocked();
+        if (!m_activePool || m_writingSlot) return false;
+
+        for (auto& slot : m_activePool->slots) {
+            if (slot.state != SlotState::Free) continue;
+            slot.state = SlotState::Writing;
+            m_writingSlot = &slot;
+            target.fbo = slot.fbo;
+            target.width = m_activePool->width;
+            target.height = m_activePool->height;
+            return true;
+        }
+        return false;
+    }
+
+    TextureInfo exportRenderTarget() override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        TextureInfo info;
+        if (!m_activePool || !m_writingSlot || m_writingSlot->state != SlotState::Writing) {
+            return info;
+        }
+
+        auto& slot = *m_writingSlot;
+        slot.state = SlotState::Exported;
+        info.handle_type = TextureHandleType::NativePixmap;
+        info.buffer_id = slot.id;
+        info.width = m_activePool->width;
+        info.height = m_activePool->height;
+        info.format = TextureFormat::BGRA8;
+        info.planes = slot.planes;
+        info.modifier = std::to_string(slot.modifier);
+        info.supports_zero_copy_webgpu_import = false;
+        info.is_valid = true;
+        m_writingSlot = nullptr;
+        return info;
+    }
+
+    void abandonRenderTarget() override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_writingSlot) {
+            m_writingSlot->state = SlotState::Free;
+            m_writingSlot = nullptr;
+        }
+    }
+
+    void releaseTexture(uint32_t buffer_id) override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        releaseFromPool(m_activePool.get(), buffer_id);
+        for (auto& pool : m_retiredPools) {
+            releaseFromPool(pool.get(), buffer_id);
+        }
+        // Retired GL resources are collected by the render thread on its next
+        // acquire/resize, where the EGL context is current.
+    }
+
+    void destroy() override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_writingSlot = nullptr;
+        destroyPool(m_activePool.get());
+        m_activePool.reset();
+        for (auto& pool : m_retiredPools) destroyPool(pool.get());
+        m_retiredPools.clear();
+        m_context = nullptr;
+    }
+
+private:
+    std::unique_ptr<DmaBufPool> createPool(uint32_t width, uint32_t height) {
+        auto pool = std::make_unique<DmaBufPool>();
+        pool->width = width;
+        pool->height = height;
+
+        for (auto& slot : pool->slots) {
+            slot.id = m_nextBufferId++;
+            if (!createSlot(slot, width, height)) {
+                destroyPool(pool.get());
+                return nullptr;
+            }
+        }
+
+        std::cout << "[LinuxDmaBuf] Created " << buffer_count << " buffers "
+                  << width << "x" << height << " on " << m_context->renderNode() << std::endl;
+        return pool;
+    }
+
+    bool createSlot(DmaBufSlot& slot, uint32_t width, uint32_t height) {
+        slot.bo = gbm_bo_create(
+            m_context->gbmDevice(),
+            width,
+            height,
+            GBM_FORMAT_ARGB8888,
+            GBM_BO_USE_RENDERING
+        );
+        if (!slot.bo) {
+            std::cerr << "[LinuxDmaBuf] GBM buffer allocation failed" << std::endl;
+            return false;
+        }
+
+        slot.modifier = gbm_bo_get_modifier(slot.bo);
+        const int plane_count = gbm_bo_get_plane_count(slot.bo);
+        if (plane_count <= 0 || plane_count > GBM_MAX_PLANES) return false;
+
+        for (int plane_index = 0; plane_index < plane_count; plane_index++) {
+            NativePixmapPlane plane;
+            plane.fd = gbm_bo_get_fd_for_plane(slot.bo, plane_index);
+            if (plane.fd < 0) return false;
+            plane.stride = gbm_bo_get_stride_for_plane(slot.bo, plane_index);
+            plane.offset = gbm_bo_get_offset(slot.bo, plane_index);
+            plane.size = planeSize(plane.fd, plane.stride, height);
+            slot.planes.push_back(plane);
+        }
+
+        slot.image = m_createImage(
+            m_context->display(),
+            EGL_NO_CONTEXT,
+            EGL_NATIVE_PIXMAP_KHR,
+            reinterpret_cast<EGLClientBuffer>(slot.bo),
+            nullptr
+        );
+        if (slot.image == EGL_NO_IMAGE_KHR) {
+            slot.image = createDmaBufImage(slot, width, height);
+        }
+        if (slot.image == EGL_NO_IMAGE_KHR) {
+            std::cerr << "[LinuxDmaBuf] EGLImage creation failed" << std::endl;
+            return false;
+        }
+
+        glGenTextures(1, &slot.texture);
+        glBindTexture(GL_TEXTURE_2D, slot.texture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        m_imageTargetTexture(GL_TEXTURE_2D, slot.image);
+
+        glGenFramebuffers(1, &slot.fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, slot.fbo);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, slot.texture, 0);
+        const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        if (status != GL_FRAMEBUFFER_COMPLETE) {
+            std::cerr << "[LinuxDmaBuf] Incomplete framebuffer: 0x" << std::hex << status << std::dec << std::endl;
+            return false;
+        }
+
+        if (m_context->debugLogging()) {
+            std::cout << "[LinuxDmaBuf] buffer=" << slot.id
+                      << " fourcc=ARGB8888 modifier=" << slot.modifier
+                      << " planes=" << slot.planes.size();
+            for (const auto& plane : slot.planes) {
+                std::cout << " [fd=" << plane.fd << " stride=" << plane.stride
+                          << " offset=" << plane.offset << " size=" << plane.size << "]";
+            }
+            std::cout << std::endl;
+        }
+        return true;
+    }
+
+    EGLImageKHR createDmaBufImage(const DmaBufSlot& slot, uint32_t width, uint32_t height) {
+        if (slot.planes.size() > 4) return EGL_NO_IMAGE_KHR;
+
+        constexpr EGLint fd_attributes[] = {
+            EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE1_FD_EXT,
+            EGL_DMA_BUF_PLANE2_FD_EXT, EGL_DMA_BUF_PLANE3_FD_EXT
+        };
+        constexpr EGLint offset_attributes[] = {
+            EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT
+        };
+        constexpr EGLint pitch_attributes[] = {
+            EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT,
+            EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT
+        };
+        constexpr EGLint modifier_low_attributes[] = {
+            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT
+        };
+        constexpr EGLint modifier_high_attributes[] = {
+            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT,
+            EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT
+        };
+
+        std::vector<EGLint> attributes = {
+            EGL_WIDTH, static_cast<EGLint>(width),
+            EGL_HEIGHT, static_cast<EGLint>(height),
+            EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(DRM_FORMAT_ARGB8888)
+        };
+        for (size_t index = 0; index < slot.planes.size(); index++) {
+            const auto& plane = slot.planes[index];
+            attributes.insert(attributes.end(), {
+                fd_attributes[index], plane.fd,
+                offset_attributes[index], static_cast<EGLint>(plane.offset),
+                pitch_attributes[index], static_cast<EGLint>(plane.stride)
+            });
+            if (slot.modifier != DRM_FORMAT_MOD_INVALID) {
+                attributes.insert(attributes.end(), {
+                    modifier_low_attributes[index], static_cast<EGLint>(slot.modifier & 0xffffffff),
+                    modifier_high_attributes[index], static_cast<EGLint>(slot.modifier >> 32)
+                });
+            }
+        }
+        attributes.push_back(EGL_NONE);
+
+        return m_createImage(
+            m_context->display(),
+            EGL_NO_CONTEXT,
+            EGL_LINUX_DMA_BUF_EXT,
+            nullptr,
+            attributes.data()
+        );
+    }
+
+    void destroySlot(DmaBufSlot& slot) {
+        if (slot.fbo) glDeleteFramebuffers(1, &slot.fbo);
+        if (slot.texture) glDeleteTextures(1, &slot.texture);
+        if (slot.image != EGL_NO_IMAGE_KHR && m_context) {
+            m_destroyImage(m_context->display(), slot.image);
+        }
+        for (const auto& plane : slot.planes) {
+            if (plane.fd >= 0) close(plane.fd);
+        }
+        if (slot.bo) gbm_bo_destroy(slot.bo);
+        slot = DmaBufSlot{};
+    }
+
+    void destroyPool(DmaBufPool* pool) {
+        if (!pool) return;
+        for (auto& slot : pool->slots) destroySlot(slot);
+    }
+
+    void cleanupRetiredPoolsLocked() {
+        auto pool = m_retiredPools.begin();
+        while (pool != m_retiredPools.end()) {
+            if (allSlotsReleased(**pool)) {
+                destroyPool(pool->get());
+                pool = m_retiredPools.erase(pool);
+            } else {
+                ++pool;
+            }
+        }
+    }
+
+    static void releaseFromPool(DmaBufPool* pool, uint32_t buffer_id) {
+        if (!pool) return;
+        for (auto& slot : pool->slots) {
+            if (slot.id == buffer_id && slot.state == SlotState::Exported) {
+                slot.state = SlotState::Free;
+                return;
+            }
+        }
+    }
+
+    LinuxEglContext* m_context = nullptr;
+    PFNEGLCREATEIMAGEKHRPROC m_createImage = nullptr;
+    PFNEGLDESTROYIMAGEKHRPROC m_destroyImage = nullptr;
+    PFNGLEGLIMAGETARGETTEXTURE2DOESPROC m_imageTargetTexture = nullptr;
+    std::unique_ptr<DmaBufPool> m_activePool;
+    std::vector<std::unique_ptr<DmaBufPool>> m_retiredPools;
+    DmaBufSlot* m_writingSlot = nullptr;
+    uint32_t m_nextBufferId = 1;
+    std::mutex m_mutex;
+};
+
+ITextureShare* createTextureShare() {
+    return new LinuxDmaBufTextureShare();
+}
+
+} // namespace mpv_texture
+
+#endif // __linux__

--- a/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
+++ b/packages/mpv-texture/src/native/linux/dmabuf_texture.cpp
@@ -81,6 +81,30 @@ public:
         m_imageTargetTexture = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(
             m_context->getProcAddress("glEGLImageTargetTexture2DOES")
         );
+        const auto query_modifiers = reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(
+            m_context->getProcAddress("eglQueryDmaBufModifiersEXT")
+        );
+        if (query_modifiers) {
+            EGLint modifier_count = 0;
+            if (query_modifiers(
+                m_context->display(), DRM_FORMAT_ARGB8888, 0, nullptr, nullptr, &modifier_count
+            ) && modifier_count > 0) {
+                std::vector<EGLuint64KHR> modifiers(modifier_count);
+                std::vector<EGLBoolean> external_only(modifier_count);
+                if (query_modifiers(
+                    m_context->display(),
+                    DRM_FORMAT_ARGB8888,
+                    modifier_count,
+                    modifiers.data(),
+                    external_only.data(),
+                    &modifier_count
+                )) {
+                    for (EGLint index = 0; index < modifier_count; index++) {
+                        if (!external_only[index]) m_renderModifiers.push_back(modifiers[index]);
+                    }
+                }
+            }
+        }
         return m_createImage && m_destroyImage && m_imageTargetTexture;
     }
 
@@ -199,13 +223,27 @@ private:
     }
 
     bool createSlot(DmaBufSlot& slot, uint32_t width, uint32_t height) {
-        slot.bo = gbm_bo_create(
+        constexpr uint64_t linear_modifier = DRM_FORMAT_MOD_LINEAR;
+        slot.bo = gbm_bo_create_with_modifiers2(
             m_context->gbmDevice(),
             width,
             height,
             GBM_FORMAT_ARGB8888,
+            &linear_modifier,
+            1,
             GBM_BO_USE_RENDERING
         );
+        if (!slot.bo && !m_renderModifiers.empty()) {
+            slot.bo = gbm_bo_create_with_modifiers2(
+                m_context->gbmDevice(),
+                width,
+                height,
+                GBM_FORMAT_ARGB8888,
+                m_renderModifiers.data(),
+                static_cast<unsigned int>(m_renderModifiers.size()),
+                GBM_BO_USE_RENDERING
+            );
+        }
         if (!slot.bo) {
             std::cerr << "[LinuxDmaBuf] GBM buffer allocation failed" << std::endl;
             return false;
@@ -369,6 +407,7 @@ private:
     PFNEGLCREATEIMAGEKHRPROC m_createImage = nullptr;
     PFNEGLDESTROYIMAGEKHRPROC m_destroyImage = nullptr;
     PFNGLEGLIMAGETARGETTEXTURE2DOESPROC m_imageTargetTexture = nullptr;
+    std::vector<uint64_t> m_renderModifiers;
     std::unique_ptr<DmaBufPool> m_activePool;
     std::vector<std::unique_ptr<DmaBufPool>> m_retiredPools;
     DmaBufSlot* m_writingSlot = nullptr;

--- a/packages/mpv-texture/src/native/linux/egl_context.cpp
+++ b/packages/mpv-texture/src/native/linux/egl_context.cpp
@@ -113,11 +113,19 @@ LinuxEglContext::~LinuxEglContext() {
 }
 
 bool LinuxEglContext::initializeDevice(const std::string& render_node) {
+    const auto fail = [this, &render_node](const char* stage) {
+        if (m_debugLogging) {
+            std::cerr << "[LinuxEGL] " << render_node << " failed at " << stage
+                      << " EGL error=0x" << std::hex << eglGetError() << std::dec << std::endl;
+        }
+        return false;
+    };
+
     m_drmFd = open(render_node.c_str(), O_RDWR | O_CLOEXEC);
-    if (m_drmFd < 0) return false;
+    if (m_drmFd < 0) return fail("open");
 
     m_gbmDevice = gbm_create_device(m_drmFd);
-    if (!m_gbmDevice) return false;
+    if (!m_gbmDevice) return fail("gbm_create_device");
 
     auto get_platform_display = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
         eglGetProcAddress("eglGetPlatformDisplayEXT")
@@ -127,15 +135,17 @@ bool LinuxEglContext::initializeDevice(const std::string& render_node) {
     } else {
         m_display = eglGetDisplay(reinterpret_cast<EGLNativeDisplayType>(m_gbmDevice));
     }
-    if (m_display == EGL_NO_DISPLAY) return false;
+    if (m_display == EGL_NO_DISPLAY) return fail("eglGetPlatformDisplay");
 
     EGLint major = 0;
     EGLint minor = 0;
-    if (!eglInitialize(m_display, &major, &minor)) return false;
-    if (!eglBindAPI(EGL_OPENGL_API)) return false;
+    if (!eglInitialize(m_display, &major, &minor)) return fail("eglInitialize");
+    if (!eglBindAPI(EGL_OPENGL_API)) return fail("eglBindAPI");
+    const char* extensions = eglQueryString(m_display, EGL_EXTENSIONS);
+    const bool supports_surfaceless = hasExtension(extensions, "EGL_KHR_surfaceless_context");
 
     const EGLint config_attributes[] = {
-        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+        EGL_SURFACE_TYPE, supports_surfaceless ? 0 : EGL_PBUFFER_BIT,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
@@ -146,7 +156,7 @@ bool LinuxEglContext::initializeDevice(const std::string& render_node) {
     EGLConfig config = nullptr;
     EGLint config_count = 0;
     if (!eglChooseConfig(m_display, config_attributes, &config, 1, &config_count) || config_count == 0) {
-        return false;
+        return fail("eglChooseConfig");
     }
 
     const EGLint context_attributes[] = {
@@ -159,20 +169,19 @@ bool LinuxEglContext::initializeDevice(const std::string& render_node) {
     if (m_context == EGL_NO_CONTEXT) {
         m_context = eglCreateContext(m_display, config, EGL_NO_CONTEXT, nullptr);
     }
-    if (m_context == EGL_NO_CONTEXT) return false;
+    if (m_context == EGL_NO_CONTEXT) return fail("eglCreateContext");
 
-    const char* extensions = eglQueryString(m_display, EGL_EXTENSIONS);
-    if (!hasExtension(extensions, "EGL_KHR_surfaceless_context")) {
+    if (!supports_surfaceless) {
         const EGLint pbuffer_attributes[] = {
             EGL_WIDTH, 1,
             EGL_HEIGHT, 1,
             EGL_NONE
         };
         m_surface = eglCreatePbufferSurface(m_display, config, pbuffer_attributes);
-        if (m_surface == EGL_NO_SURFACE) return false;
+        if (m_surface == EGL_NO_SURFACE) return fail("eglCreatePbufferSurface");
     }
 
-    if (!makeCurrent()) return false;
+    if (!makeCurrent()) return fail("eglMakeCurrent");
     m_renderNode = render_node;
 
     if (m_debugLogging) {

--- a/packages/mpv-texture/src/native/linux/egl_context.cpp
+++ b/packages/mpv-texture/src/native/linux/egl_context.cpp
@@ -1,0 +1,230 @@
+#ifdef __linux__
+
+#include "egl_context.h"
+
+#include <EGL/eglext.h>
+#include <GL/gl.h>
+#include <fcntl.h>
+#include <gbm.h>
+#include <unistd.h>
+#include <xf86drm.h>
+
+#include <algorithm>
+#include <cstring>
+#include <dlfcn.h>
+#include <iostream>
+#include <vector>
+
+namespace mpv_texture {
+
+namespace {
+
+struct RenderNodeCandidate {
+    std::string path;
+    uint32_t vendor_id = 0;
+    uint32_t device_id = 0;
+    bool preferred = false;
+};
+
+std::vector<RenderNodeCandidate> enumerateRenderNodes(
+    uint32_t preferred_vendor_id,
+    uint32_t preferred_device_id
+) {
+    constexpr int max_devices = 32;
+    drmDevicePtr devices[max_devices] = {};
+    const int count = drmGetDevices2(0, devices, max_devices);
+    std::vector<RenderNodeCandidate> candidates;
+
+    if (count < 0) {
+        std::cerr << "[LinuxEGL] Failed to enumerate DRM devices" << std::endl;
+        return candidates;
+    }
+
+    for (int index = 0; index < count; index++) {
+        const auto* device = devices[index];
+        if (!device || !(device->available_nodes & (1 << DRM_NODE_RENDER))) {
+            continue;
+        }
+
+        RenderNodeCandidate candidate;
+        candidate.path = device->nodes[DRM_NODE_RENDER];
+        if (device->bustype == DRM_BUS_PCI && device->deviceinfo.pci) {
+            candidate.vendor_id = device->deviceinfo.pci->vendor_id;
+            candidate.device_id = device->deviceinfo.pci->device_id;
+        }
+        candidate.preferred = preferred_vendor_id != 0 &&
+            candidate.vendor_id == preferred_vendor_id &&
+            (preferred_device_id == 0 || candidate.device_id == preferred_device_id);
+        candidates.push_back(std::move(candidate));
+    }
+
+    drmFreeDevices(devices, count);
+    std::stable_sort(candidates.begin(), candidates.end(), [](const auto& left, const auto& right) {
+        return left.preferred && !right.preferred;
+    });
+    return candidates;
+}
+
+bool hasExtension(const char* extensions, const char* extension) {
+    if (!extensions || !extension) return false;
+    const std::string all_extensions = extensions;
+    const std::string wanted = extension;
+    size_t position = 0;
+    while ((position = all_extensions.find(wanted, position)) != std::string::npos) {
+        const bool starts_at_boundary = position == 0 || all_extensions[position - 1] == ' ';
+        const size_t end = position + wanted.size();
+        const bool ends_at_boundary = end == all_extensions.size() || all_extensions[end] == ' ';
+        if (starts_at_boundary && ends_at_boundary) return true;
+        position = end;
+    }
+    return false;
+}
+
+} // namespace
+
+std::unique_ptr<LinuxEglContext> LinuxEglContext::create(
+    uint32_t preferred_vendor_id,
+    uint32_t preferred_device_id,
+    bool debug_logging
+) {
+    auto context = std::unique_ptr<LinuxEglContext>(new LinuxEglContext());
+    context->m_debugLogging = debug_logging;
+
+    const auto candidates = enumerateRenderNodes(preferred_vendor_id, preferred_device_id);
+    for (const auto& candidate : candidates) {
+        if (debug_logging) {
+            std::cout << "[LinuxEGL] Trying " << candidate.path
+                      << " vendor=0x" << std::hex << candidate.vendor_id
+                      << " device=0x" << candidate.device_id << std::dec
+                      << (candidate.preferred ? " (Chromium match)" : "") << std::endl;
+        }
+        if (context->initializeDevice(candidate.path)) {
+            return context;
+        }
+        context->destroyDevice();
+    }
+
+    std::cerr << "[LinuxEGL] No usable DRM render node found" << std::endl;
+    return nullptr;
+}
+
+LinuxEglContext::~LinuxEglContext() {
+    destroyDevice();
+}
+
+bool LinuxEglContext::initializeDevice(const std::string& render_node) {
+    m_drmFd = open(render_node.c_str(), O_RDWR | O_CLOEXEC);
+    if (m_drmFd < 0) return false;
+
+    m_gbmDevice = gbm_create_device(m_drmFd);
+    if (!m_gbmDevice) return false;
+
+    auto get_platform_display = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+        eglGetProcAddress("eglGetPlatformDisplayEXT")
+    );
+    if (get_platform_display) {
+        m_display = get_platform_display(EGL_PLATFORM_GBM_KHR, m_gbmDevice, nullptr);
+    } else {
+        m_display = eglGetDisplay(reinterpret_cast<EGLNativeDisplayType>(m_gbmDevice));
+    }
+    if (m_display == EGL_NO_DISPLAY) return false;
+
+    EGLint major = 0;
+    EGLint minor = 0;
+    if (!eglInitialize(m_display, &major, &minor)) return false;
+    if (!eglBindAPI(EGL_OPENGL_API)) return false;
+
+    const EGLint config_attributes[] = {
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_NONE
+    };
+    EGLConfig config = nullptr;
+    EGLint config_count = 0;
+    if (!eglChooseConfig(m_display, config_attributes, &config, 1, &config_count) || config_count == 0) {
+        return false;
+    }
+
+    const EGLint context_attributes[] = {
+        EGL_CONTEXT_MAJOR_VERSION_KHR, 3,
+        EGL_CONTEXT_MINOR_VERSION_KHR, 2,
+        EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
+        EGL_NONE
+    };
+    m_context = eglCreateContext(m_display, config, EGL_NO_CONTEXT, context_attributes);
+    if (m_context == EGL_NO_CONTEXT) {
+        m_context = eglCreateContext(m_display, config, EGL_NO_CONTEXT, nullptr);
+    }
+    if (m_context == EGL_NO_CONTEXT) return false;
+
+    const char* extensions = eglQueryString(m_display, EGL_EXTENSIONS);
+    if (!hasExtension(extensions, "EGL_KHR_surfaceless_context")) {
+        const EGLint pbuffer_attributes[] = {
+            EGL_WIDTH, 1,
+            EGL_HEIGHT, 1,
+            EGL_NONE
+        };
+        m_surface = eglCreatePbufferSurface(m_display, config, pbuffer_attributes);
+        if (m_surface == EGL_NO_SURFACE) return false;
+    }
+
+    if (!makeCurrent()) return false;
+    m_renderNode = render_node;
+
+    if (m_debugLogging) {
+        const auto* vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+        const auto* renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+        std::cout << "[LinuxEGL] Selected " << m_renderNode
+                  << " GBM=" << gbm_device_get_backend_name(m_gbmDevice)
+                  << " EGL=" << eglQueryString(m_display, EGL_VENDOR)
+                  << " GL=" << (vendor ? vendor : "unknown")
+                  << " renderer=" << (renderer ? renderer : "unknown") << std::endl;
+    }
+    return true;
+}
+
+void LinuxEglContext::destroyDevice() {
+    if (m_display != EGL_NO_DISPLAY) {
+        eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        if (m_surface != EGL_NO_SURFACE) {
+            eglDestroySurface(m_display, m_surface);
+        }
+        if (m_context != EGL_NO_CONTEXT) {
+            eglDestroyContext(m_display, m_context);
+        }
+        eglTerminate(m_display);
+    }
+    if (m_gbmDevice) gbm_device_destroy(m_gbmDevice);
+    if (m_drmFd >= 0) close(m_drmFd);
+
+    m_surface = EGL_NO_SURFACE;
+    m_context = EGL_NO_CONTEXT;
+    m_display = EGL_NO_DISPLAY;
+    m_gbmDevice = nullptr;
+    m_drmFd = -1;
+    m_renderNode.clear();
+}
+
+bool LinuxEglContext::makeCurrent() {
+    if (m_display == EGL_NO_DISPLAY || m_context == EGL_NO_CONTEXT) return false;
+    return eglMakeCurrent(m_display, m_surface, m_surface, m_context) == EGL_TRUE;
+}
+
+void LinuxEglContext::clearCurrent() {
+    if (m_display != EGL_NO_DISPLAY) {
+        eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    }
+}
+
+void* LinuxEglContext::getProcAddress(const char* name) const {
+    void* address = reinterpret_cast<void*>(eglGetProcAddress(name));
+    return address ? address : dlsym(RTLD_DEFAULT, name);
+}
+
+} // namespace mpv_texture
+
+#endif // __linux__

--- a/packages/mpv-texture/src/native/linux/egl_context.h
+++ b/packages/mpv-texture/src/native/linux/egl_context.h
@@ -1,0 +1,53 @@
+#ifndef LINUX_EGL_CONTEXT_H_
+#define LINUX_EGL_CONTEXT_H_
+
+#ifdef __linux__
+
+#include <EGL/egl.h>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+struct gbm_device;
+
+namespace mpv_texture {
+
+class LinuxEglContext {
+public:
+    static std::unique_ptr<LinuxEglContext> create(
+        uint32_t preferred_vendor_id,
+        uint32_t preferred_device_id,
+        bool debug_logging
+    );
+
+    ~LinuxEglContext();
+
+    bool makeCurrent();
+    void clearCurrent();
+    void* getProcAddress(const char* name) const;
+
+    EGLDisplay display() const { return m_display; }
+    gbm_device* gbmDevice() const { return m_gbmDevice; }
+    const std::string& renderNode() const { return m_renderNode; }
+    bool debugLogging() const { return m_debugLogging; }
+
+private:
+    LinuxEglContext() = default;
+
+    bool initializeDevice(const std::string& render_node);
+    void destroyDevice();
+
+    int m_drmFd = -1;
+    gbm_device* m_gbmDevice = nullptr;
+    EGLDisplay m_display = EGL_NO_DISPLAY;
+    EGLContext m_context = EGL_NO_CONTEXT;
+    EGLSurface m_surface = EGL_NO_SURFACE;
+    std::string m_renderNode;
+    bool m_debugLogging = false;
+};
+
+} // namespace mpv_texture
+
+#endif // __linux__
+
+#endif // LINUX_EGL_CONTEXT_H_

--- a/packages/mpv-texture/src/native/macos/iosurface_texture.mm
+++ b/packages/mpv-texture/src/native/macos/iosurface_texture.mm
@@ -77,22 +77,17 @@ public:
         return createTexture(width, height);
     }
 
-    uint32_t getGLTexture() const override {
-        return m_slots[m_writeIndex].glTexture;
-    }
-
-    uint32_t getGLFBO() const override {
-        return m_slots[m_writeIndex].glFBO;
-    }
-
-    bool lockTexture() override {
+    bool acquireRenderTarget(RenderTarget& target) override {
         if (!m_slots[m_writeIndex].ioSurface) return false;
         // No IOSurfaceLock needed — GPU-to-GPU sharing uses glFlush for sync
         m_locked = true;
+        target.fbo = m_slots[m_writeIndex].glFBO;
+        target.width = m_width;
+        target.height = m_height;
         return true;
     }
 
-    TextureInfo unlockAndExport() override {
+    TextureInfo exportRenderTarget() override {
         TextureInfo info = {};
 
         if (!m_locked) {
@@ -105,6 +100,7 @@ public:
 
         // Pass IOSurfaceRef as raw pointer — Electron's importSharedTexture expects
         // the ioSurface Buffer to contain the IOSurfaceRef pointer, not the IOSurfaceID.
+        info.handle_type = TextureHandleType::IOSurface;
         info.handle = reinterpret_cast<uint64_t>(slot.ioSurface);
         info.width = m_width;
         info.height = m_height;
@@ -117,7 +113,11 @@ public:
         return info;
     }
 
-    void releaseTexture() override {
+    void abandonRenderTarget() override {
+        m_locked = false;
+    }
+
+    void releaseTexture(uint32_t) override {
         // No-op with triple buffering - mpv always has a free slot to write to
     }
 

--- a/packages/mpv-texture/src/native/mpv_api.cpp
+++ b/packages/mpv-texture/src/native/mpv_api.cpp
@@ -1,0 +1,89 @@
+#ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <dlfcn.h>
+#endif
+
+#include "mpv_api.h"
+
+namespace mpv_texture {
+
+MpvApi& mpvApi() {
+    static MpvApi api;
+    return api;
+}
+
+bool MpvApi::load(std::string& error) {
+    if (create) return true;
+
+#ifdef __linux__
+    // These libraries exchange allocated memory across their own DSOs. Resolve
+    // them normally before deep-binding libmpv so each uses one allocator.
+    static void* pipewire = dlopen("libpipewire-0.3.so.0", RTLD_NOW | RTLD_GLOBAL);
+    static void* libass = dlopen("libass.so.9", RTLD_NOW | RTLD_GLOBAL);
+    static void* pulse = dlopen("libpulse.so.0", RTLD_NOW | RTLD_GLOBAL);
+    (void)pipewire;
+    (void)libass;
+    (void)pulse;
+
+    void* library = nullptr;
+    const char* library_names[] = {"libmpv.so.2", "libmpv.so.1", "libmpv.so"};
+    for (const char* library_name : library_names) {
+        library = dlopen(library_name, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
+        if (library) break;
+    }
+    if (!library) {
+        const char* loader_error = dlerror();
+        error = loader_error ? loader_error : "system libmpv not found";
+        return false;
+    }
+
+#define LOAD_MPV_SYMBOL(member, symbol) \
+    member = reinterpret_cast<decltype(member)>(dlsym(library, symbol)); \
+    if (!member) { error = std::string("missing libmpv symbol: ") + symbol; return false; }
+
+    LOAD_MPV_SYMBOL(create, "mpv_create");
+    LOAD_MPV_SYMBOL(initialize, "mpv_initialize");
+    LOAD_MPV_SYMBOL(destroy, "mpv_destroy");
+    LOAD_MPV_SYMBOL(terminateDestroy, "mpv_terminate_destroy");
+    LOAD_MPV_SYMBOL(setOptionString, "mpv_set_option_string");
+    LOAD_MPV_SYMBOL(setProperty, "mpv_set_property");
+    LOAD_MPV_SYMBOL(command, "mpv_command");
+    LOAD_MPV_SYMBOL(errorString, "mpv_error_string");
+    LOAD_MPV_SYMBOL(observeProperty, "mpv_observe_property");
+    LOAD_MPV_SYMBOL(setWakeupCallback, "mpv_set_wakeup_callback");
+    LOAD_MPV_SYMBOL(waitEvent, "mpv_wait_event");
+    LOAD_MPV_SYMBOL(wakeup, "mpv_wakeup");
+    LOAD_MPV_SYMBOL(renderContextCreate, "mpv_render_context_create");
+    LOAD_MPV_SYMBOL(renderContextFree, "mpv_render_context_free");
+    LOAD_MPV_SYMBOL(renderContextSetUpdateCallback, "mpv_render_context_set_update_callback");
+    LOAD_MPV_SYMBOL(renderContextUpdate, "mpv_render_context_update");
+    LOAD_MPV_SYMBOL(renderContextRender, "mpv_render_context_render");
+    LOAD_MPV_SYMBOL(renderContextReportSwap, "mpv_render_context_report_swap");
+
+#undef LOAD_MPV_SYMBOL
+#else
+    create = &::mpv_create;
+    initialize = &::mpv_initialize;
+    destroy = &::mpv_destroy;
+    terminateDestroy = &::mpv_terminate_destroy;
+    setOptionString = &::mpv_set_option_string;
+    setProperty = &::mpv_set_property;
+    command = &::mpv_command;
+    errorString = &::mpv_error_string;
+    observeProperty = &::mpv_observe_property;
+    setWakeupCallback = &::mpv_set_wakeup_callback;
+    waitEvent = &::mpv_wait_event;
+    wakeup = &::mpv_wakeup;
+    renderContextCreate = &::mpv_render_context_create;
+    renderContextFree = &::mpv_render_context_free;
+    renderContextSetUpdateCallback = &::mpv_render_context_set_update_callback;
+    renderContextUpdate = &::mpv_render_context_update;
+    renderContextRender = &::mpv_render_context_render;
+    renderContextReportSwap = &::mpv_render_context_report_swap;
+#endif
+    return true;
+}
+
+} // namespace mpv_texture

--- a/packages/mpv-texture/src/native/mpv_api.h
+++ b/packages/mpv-texture/src/native/mpv_api.h
@@ -1,0 +1,40 @@
+#ifndef MPV_API_H_
+#define MPV_API_H_
+
+#include <mpv/client.h>
+#include <mpv/render.h>
+#include <string>
+
+namespace mpv_texture {
+
+// Electron and system libmpv may use incompatible FFmpeg builds. Linux loads
+// libmpv into a private, deep-bound scope so its dependency versions take
+// precedence over Electron's global FFmpeg symbols.
+struct MpvApi {
+    decltype(&::mpv_create) create = nullptr;
+    decltype(&::mpv_initialize) initialize = nullptr;
+    decltype(&::mpv_destroy) destroy = nullptr;
+    decltype(&::mpv_terminate_destroy) terminateDestroy = nullptr;
+    decltype(&::mpv_set_option_string) setOptionString = nullptr;
+    decltype(&::mpv_set_property) setProperty = nullptr;
+    decltype(&::mpv_command) command = nullptr;
+    decltype(&::mpv_error_string) errorString = nullptr;
+    decltype(&::mpv_observe_property) observeProperty = nullptr;
+    decltype(&::mpv_set_wakeup_callback) setWakeupCallback = nullptr;
+    decltype(&::mpv_wait_event) waitEvent = nullptr;
+    decltype(&::mpv_wakeup) wakeup = nullptr;
+    decltype(&::mpv_render_context_create) renderContextCreate = nullptr;
+    decltype(&::mpv_render_context_free) renderContextFree = nullptr;
+    decltype(&::mpv_render_context_set_update_callback) renderContextSetUpdateCallback = nullptr;
+    decltype(&::mpv_render_context_update) renderContextUpdate = nullptr;
+    decltype(&::mpv_render_context_render) renderContextRender = nullptr;
+    decltype(&::mpv_render_context_report_swap) renderContextReportSwap = nullptr;
+
+    bool load(std::string& error);
+};
+
+MpvApi& mpvApi();
+
+} // namespace mpv_texture
+
+#endif // MPV_API_H_

--- a/packages/mpv-texture/src/native/mpv_context.cpp
+++ b/packages/mpv-texture/src/native/mpv_context.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "mpv_context.h"
+#include "mpv_api.h"
 #include <cstring>
 #include <iostream>
 #include <memory>
@@ -193,6 +194,12 @@ bool MpvContext::create(const MpvConfig& config) {
 
     m_config = config;
 
+    std::string mpvLoadError;
+    if (!mpvApi().load(mpvLoadError)) {
+        if (m_errorCallback) m_errorCallback("Failed to load libmpv: " + mpvLoadError);
+        return false;
+    }
+
 #ifdef _WIN32
     // Create Windows GL context first (required for WGL extensions)
     if (!createWindowsGLContext()) {
@@ -224,8 +231,10 @@ bool MpvContext::create(const MpvConfig& config) {
     m_glContext = static_cast<void*>(g_linuxEglContext.get());
 #endif
 
+    if (config.debugLogging) std::cout << "[MpvContext] Creating libmpv handle" << std::endl;
+
     // Create mpv handle
-    m_mpv = mpv_create();
+    m_mpv = mpvApi().create();
     if (!m_mpv) {
         if (m_errorCallback) {
             m_errorCallback("Failed to create mpv context");
@@ -234,30 +243,47 @@ bool MpvContext::create(const MpvConfig& config) {
     }
 
     // Set options before initialization
-    mpv_set_option_string(m_mpv, "vo", config.vo.c_str());
-    mpv_set_option_string(m_mpv, "hwdec", config.hwdec.c_str());
-    mpv_set_option_string(m_mpv, "keep-open", "yes");
-    mpv_set_option_string(m_mpv, "idle", "yes");
-    mpv_set_option_string(m_mpv, "terminal", "no");
-    mpv_set_option_string(m_mpv, "msg-level", "all=v");
+    mpvApi().setOptionString(m_mpv, "vo", config.vo.c_str());
+    mpvApi().setOptionString(m_mpv, "hwdec", config.hwdec.c_str());
+    mpvApi().setOptionString(m_mpv, "keep-open", "yes");
+    mpvApi().setOptionString(m_mpv, "idle", "yes");
+    mpvApi().setOptionString(m_mpv, "terminal", "no");
+    mpvApi().setOptionString(m_mpv, "osc", "no");
+    mpvApi().setOptionString(m_mpv, "load-scripts", "no");
+    mpvApi().setOptionString(m_mpv, "load-console", "no");
+    mpvApi().setOptionString(m_mpv, "load-context-menu", "no");
+    mpvApi().setOptionString(m_mpv, "load-commands", "no");
+    mpvApi().setOptionString(m_mpv, "load-positioning", "no");
+    mpvApi().setOptionString(m_mpv, "load-select", "no");
+    mpvApi().setOptionString(m_mpv, "load-stats-overlay", "no");
+    mpvApi().setOptionString(m_mpv, "input-default-bindings", "no");
+    mpvApi().setOptionString(m_mpv, "msg-level", "all=v");
+#ifdef __linux__
+    // The PipeWire client library cannot safely cross Electron's FFmpeg
+    // isolation boundary. PulseAudio remains available through PipeWire's
+    // compatibility server on current Linux desktops.
+    mpvApi().setOptionString(m_mpv, "ao", "pulse,alsa");
+#endif
 
     // Initialize mpv
-    if (mpv_initialize(m_mpv) < 0) {
+    if (config.debugLogging) std::cout << "[MpvContext] Initializing libmpv" << std::endl;
+    if (mpvApi().initialize(m_mpv) < 0) {
         if (m_errorCallback) {
             m_errorCallback("Failed to initialize mpv");
         }
-        mpv_destroy(m_mpv);
+        mpvApi().destroy(m_mpv);
         m_mpv = nullptr;
         return false;
     }
 
     // Create texture sharing
+    if (config.debugLogging) std::cout << "[MpvContext] Initializing texture adapter" << std::endl;
     m_textureShare = createTextureShare();
     if (!m_textureShare) {
         if (m_errorCallback) {
             m_errorCallback("Failed to create texture share");
         }
-        mpv_terminate_destroy(m_mpv);
+        mpvApi().terminateDestroy(m_mpv);
         m_mpv = nullptr;
         return false;
     }
@@ -270,12 +296,13 @@ bool MpvContext::create(const MpvConfig& config) {
         }
         delete m_textureShare;
         m_textureShare = nullptr;
-        mpv_terminate_destroy(m_mpv);
+        mpvApi().terminateDestroy(m_mpv);
         m_mpv = nullptr;
         return false;
     }
 
     // Create shared texture
+    if (config.debugLogging) std::cout << "[MpvContext] Allocating shared textures" << std::endl;
     if (!m_textureShare->createTexture(config.width, config.height)) {
         if (m_errorCallback) {
             m_errorCallback("Failed to create shared texture");
@@ -283,12 +310,13 @@ bool MpvContext::create(const MpvConfig& config) {
         m_textureShare->destroy();
         delete m_textureShare;
         m_textureShare = nullptr;
-        mpv_terminate_destroy(m_mpv);
+        mpvApi().terminateDestroy(m_mpv);
         m_mpv = nullptr;
         return false;
     }
 
     // Create render context
+    if (config.debugLogging) std::cout << "[MpvContext] Creating libmpv render context" << std::endl;
     mpv_opengl_init_params gl_init_params{
         .get_proc_address = getProcAddress,
         .get_proc_address_ctx = this,
@@ -302,32 +330,32 @@ bool MpvContext::create(const MpvConfig& config) {
         {MPV_RENDER_PARAM_INVALID, nullptr}
     };
 
-    if (mpv_render_context_create(&m_renderCtx, m_mpv, params) < 0) {
+    if (mpvApi().renderContextCreate(&m_renderCtx, m_mpv, params) < 0) {
         if (m_errorCallback) {
             m_errorCallback("Failed to create mpv render context");
         }
         m_textureShare->destroy();
         delete m_textureShare;
         m_textureShare = nullptr;
-        mpv_terminate_destroy(m_mpv);
+        mpvApi().terminateDestroy(m_mpv);
         m_mpv = nullptr;
         return false;
     }
 
     // Set up render update callback
-    mpv_render_context_set_update_callback(m_renderCtx, renderUpdateCallback, this);
+    mpvApi().renderContextSetUpdateCallback(m_renderCtx, renderUpdateCallback, this);
 
     // Set up wakeup callback for event handling
-    mpv_set_wakeup_callback(m_mpv, wakeupCallback, this);
+    mpvApi().setWakeupCallback(m_mpv, wakeupCallback, this);
 
     // Observe properties
-    mpv_observe_property(m_mpv, 1, "pause", MPV_FORMAT_FLAG);
-    mpv_observe_property(m_mpv, 2, "volume", MPV_FORMAT_DOUBLE);
-    mpv_observe_property(m_mpv, 3, "mute", MPV_FORMAT_FLAG);
-    mpv_observe_property(m_mpv, 4, "time-pos", MPV_FORMAT_DOUBLE);
-    mpv_observe_property(m_mpv, 5, "duration", MPV_FORMAT_DOUBLE);
-    mpv_observe_property(m_mpv, 6, "width", MPV_FORMAT_INT64);
-    mpv_observe_property(m_mpv, 7, "height", MPV_FORMAT_INT64);
+    mpvApi().observeProperty(m_mpv, 1, "pause", MPV_FORMAT_FLAG);
+    mpvApi().observeProperty(m_mpv, 2, "volume", MPV_FORMAT_DOUBLE);
+    mpvApi().observeProperty(m_mpv, 3, "mute", MPV_FORMAT_FLAG);
+    mpvApi().observeProperty(m_mpv, 4, "time-pos", MPV_FORMAT_DOUBLE);
+    mpvApi().observeProperty(m_mpv, 5, "duration", MPV_FORMAT_DOUBLE);
+    mpvApi().observeProperty(m_mpv, 6, "width", MPV_FORMAT_INT64);
+    mpvApi().observeProperty(m_mpv, 7, "height", MPV_FORMAT_INT64);
 
     // Start threads
     m_running = true;
@@ -357,7 +385,7 @@ void MpvContext::destroy() {
 
     // Stop mpv first to unblock event loop
     if (m_mpv) {
-        mpv_wakeup(m_mpv);
+        mpvApi().wakeup(m_mpv);
     }
 
     if (m_eventThread.joinable()) {
@@ -375,12 +403,12 @@ void MpvContext::destroy() {
 #endif
 
     if (m_renderCtx) {
-        mpv_render_context_free(m_renderCtx);
+        mpvApi().renderContextFree(m_renderCtx);
         m_renderCtx = nullptr;
     }
 
     if (m_mpv) {
-        mpv_terminate_destroy(m_mpv);
+        mpvApi().terminateDestroy(m_mpv);
         m_mpv = nullptr;
     }
 
@@ -410,48 +438,48 @@ bool MpvContext::load(const std::string& url, const std::string& options) {
 
     if (!options.empty()) {
         const char* cmd[] = {"loadfile", url.c_str(), "replace", options.c_str(), nullptr};
-        int result = mpv_command(m_mpv, cmd);
+        int result = mpvApi().command(m_mpv, cmd);
         return result >= 0;
     }
     const char* cmd[] = {"loadfile", url.c_str(), nullptr};
-    int result = mpv_command(m_mpv, cmd);
+    int result = mpvApi().command(m_mpv, cmd);
     return result >= 0;
 }
 
 void MpvContext::play() {
     if (!m_mpv) return;
     int flag = 0;
-    mpv_set_property(m_mpv, "pause", MPV_FORMAT_FLAG, &flag);
+    mpvApi().setProperty(m_mpv, "pause", MPV_FORMAT_FLAG, &flag);
 }
 
 void MpvContext::pause() {
     if (!m_mpv) return;
     int flag = 1;
-    mpv_set_property(m_mpv, "pause", MPV_FORMAT_FLAG, &flag);
+    mpvApi().setProperty(m_mpv, "pause", MPV_FORMAT_FLAG, &flag);
 }
 
 void MpvContext::stop() {
     if (!m_mpv) return;
     const char* cmd[] = {"stop", nullptr};
-    mpv_command(m_mpv, cmd);
+    mpvApi().command(m_mpv, cmd);
 }
 
 void MpvContext::seek(double position) {
     if (!m_mpv) return;
     std::string pos_str = std::to_string(position);
     const char* cmd[] = {"seek", pos_str.c_str(), "absolute", nullptr};
-    mpv_command(m_mpv, cmd);
+    mpvApi().command(m_mpv, cmd);
 }
 
 void MpvContext::setVolume(double volume) {
     if (!m_mpv) return;
-    mpv_set_property(m_mpv, "volume", MPV_FORMAT_DOUBLE, &volume);
+    mpvApi().setProperty(m_mpv, "volume", MPV_FORMAT_DOUBLE, &volume);
 }
 
 void MpvContext::toggleMute() {
     if (!m_mpv) return;
     const char* cmd[] = {"cycle", "mute", nullptr};
-    mpv_command(m_mpv, cmd);
+    mpvApi().command(m_mpv, cmd);
 }
 
 void MpvContext::setFrameCallback(FrameCallback callback) {
@@ -480,7 +508,7 @@ MpvStatus MpvContext::getStatus() const {
 
 void MpvContext::eventLoop() {
     while (m_running) {
-        mpv_event* event = mpv_wait_event(m_mpv, 0.1);
+        mpv_event* event = mpvApi().waitEvent(m_mpv, 0.1);
         if (event->event_id == MPV_EVENT_NONE) {
             continue;
         }
@@ -501,7 +529,7 @@ void MpvContext::handleEvent(mpv_event* event) {
             if (end_file->reason == MPV_END_FILE_REASON_ERROR) {
                 std::lock_guard<std::mutex> lock(m_callbackMutex);
                 if (m_errorCallback) {
-                    m_errorCallback("Playback error: " + std::string(mpv_error_string(end_file->error)));
+                    m_errorCallback("Playback error: " + std::string(mpvApi().errorString(end_file->error)));
                 }
             }
             break;
@@ -649,7 +677,7 @@ void MpvContext::renderLoop() {
         }
 
         // Check if we can render
-        uint64_t flags = mpv_render_context_update(m_renderCtx);
+        uint64_t flags = mpvApi().renderContextUpdate(m_renderCtx);
         if (!(flags & MPV_RENDER_UPDATE_FRAME)) {
             continue;
         }
@@ -679,14 +707,14 @@ void MpvContext::renderLoop() {
             {MPV_RENDER_PARAM_INVALID, nullptr}
         };
 
-        int result = mpv_render_context_render(m_renderCtx, params);
+        int result = mpvApi().renderContextRender(m_renderCtx, params);
         if (result < 0) {
             m_textureShare->abandonRenderTarget();
             continue;
         }
 
         // Report swap
-        mpv_render_context_report_swap(m_renderCtx);
+        mpvApi().renderContextReportSwap(m_renderCtx);
 
         // Flush GL commands to ensure rendering is complete before export.
         // macOS: glFlush is sufficient for GPU-to-GPU IOSurface sharing.

--- a/packages/mpv-texture/src/native/mpv_context.cpp
+++ b/packages/mpv-texture/src/native/mpv_context.cpp
@@ -693,6 +693,15 @@ void MpvContext::renderLoop() {
                 std::cout << "[MpvContext] No free texture slot; dropping frame" << std::endl;
                 lockFailCount++;
             }
+
+            int skip_rendering = 1;
+            mpv_render_param skip_params[] = {
+                {MPV_RENDER_PARAM_SKIP_RENDERING, &skip_rendering},
+                {MPV_RENDER_PARAM_INVALID, nullptr}
+            };
+            if (mpvApi().renderContextRender(m_renderCtx, skip_params) >= 0) {
+                mpvApi().renderContextReportSwap(m_renderCtx);
+            }
             continue;
         }
 

--- a/packages/mpv-texture/src/native/mpv_context.cpp
+++ b/packages/mpv-texture/src/native/mpv_context.cpp
@@ -5,6 +5,7 @@
 #include "mpv_context.h"
 #include <cstring>
 #include <iostream>
+#include <memory>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -19,8 +20,8 @@ typedef PROC(WINAPI* PFNWGLGETPROCADDRESSPROC)(LPCSTR);
 #include <OpenGL/OpenGL.h>
 #include <dlfcn.h>
 #else
+#include "linux/egl_context.h"
 #include <GL/gl.h>
-#include <GL/glx.h>
 #endif
 
 namespace mpv_texture {
@@ -124,6 +125,10 @@ static void destroyWindowsGLContext() {
 }
 #endif
 
+#ifdef __linux__
+static std::unique_ptr<LinuxEglContext> g_linuxEglContext;
+#endif
+
 #ifdef __APPLE__
 static CGLContextObj g_cglContext = nullptr;
 static CGLPixelFormatObj g_cglPixelFormat = nullptr;
@@ -206,6 +211,17 @@ bool MpvContext::create(const MpvConfig& config) {
         return false;
     }
     m_glContext = static_cast<void*>(g_cglContext);
+#elif defined(__linux__)
+    g_linuxEglContext = LinuxEglContext::create(
+        config.gpuVendorId,
+        config.gpuDeviceId,
+        config.debugLogging
+    );
+    if (!g_linuxEglContext) {
+        if (m_errorCallback) m_errorCallback("Failed to create Linux EGL context");
+        return false;
+    }
+    m_glContext = static_cast<void*>(g_linuxEglContext.get());
 #endif
 
     // Create mpv handle
@@ -324,6 +340,8 @@ bool MpvContext::create(const MpvConfig& config) {
 #elif defined(__APPLE__)
     // Release CGL context from main thread so render thread can use it
     CGLSetCurrentContext(nullptr);
+#elif defined(__linux__)
+    g_linuxEglContext->clearCurrent();
 #endif
 
     m_renderThread = std::thread(&MpvContext::renderLoop, this);
@@ -333,10 +351,6 @@ bool MpvContext::create(const MpvConfig& config) {
 }
 
 void MpvContext::destroy() {
-    if (!m_initialized) {
-        return;
-    }
-
     m_running = false;
     m_needsRender = true;
     m_renderCV.notify_one();
@@ -353,6 +367,12 @@ void MpvContext::destroy() {
     if (m_renderThread.joinable()) {
         m_renderThread.join();
     }
+
+#ifdef __linux__
+    // mpv render and texture teardown make GL calls. Reacquire the context on
+    // this thread after the render thread exits.
+    if (g_linuxEglContext) g_linuxEglContext->makeCurrent();
+#endif
 
     if (m_renderCtx) {
         mpv_render_context_free(m_renderCtx);
@@ -375,6 +395,10 @@ void MpvContext::destroy() {
     m_glContext = nullptr;
 #elif defined(__APPLE__)
     destroyMacOSGLContext();
+    m_glContext = nullptr;
+#elif defined(__linux__)
+    if (g_linuxEglContext) g_linuxEglContext->clearCurrent();
+    g_linuxEglContext.reset();
     m_glContext = nullptr;
 #endif
 
@@ -445,12 +469,8 @@ void MpvContext::setErrorCallback(ErrorCallback callback) {
     m_errorCallback = std::move(callback);
 }
 
-void MpvContext::releaseFrame() {
-    std::lock_guard<std::mutex> lock(m_frameMutex);
-    if (m_frameInUse) {
-        m_textureShare->releaseTexture();
-        m_frameInUse = false;
-    }
+void MpvContext::releaseFrame(uint32_t buffer_id) {
+    if (m_textureShare) m_textureShare->releaseTexture(buffer_id);
 }
 
 MpvStatus MpvContext::getStatus() const {
@@ -596,6 +616,16 @@ void MpvContext::renderLoop() {
         }
         std::cout << "[MpvContext] CGL context made current in render thread" << std::endl;
     }
+#elif defined(__linux__)
+    if (!g_linuxEglContext || !g_linuxEglContext->makeCurrent()) {
+        std::cerr << "[MpvContext] Failed to make EGL context current in render thread" << std::endl;
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        if (m_errorCallback) {
+            m_errorCallback("Render thread failed: could not make EGL context current");
+        }
+        return;
+    }
+    std::cout << "[MpvContext] EGL context made current in render thread" << std::endl;
 #endif
 
     while (m_running) {
@@ -624,34 +654,21 @@ void MpvContext::renderLoop() {
             continue;
         }
 
-        // No m_frameInUse check needed — triple buffering eliminates contention.
-        // macOS: IOSurface uses glFlush for GPU-to-GPU sync.
-        // Windows (future): keyed mutex / AcquireSync will handle sync instead.
-
-        // Lock texture for rendering
-        if (!m_textureShare->lockTexture()) {
+        RenderTarget target;
+        if (!m_textureShare->acquireRenderTarget(target)) {
             static int lockFailCount = 0;
             if (lockFailCount < 5) {
-                std::cout << "[MpvContext] Failed to lock texture" << std::endl;
+                std::cout << "[MpvContext] No free texture slot; dropping frame" << std::endl;
                 lockFailCount++;
             }
             continue;
         }
 
-        // Get FBO and dimensions
-        int fbo = m_textureShare->getGLFBO();
-        int width, height;
-        {
-            std::lock_guard<std::mutex> lock(m_statusMutex);
-            width = m_status.width > 0 ? m_status.width : m_config.width;
-            height = m_status.height > 0 ? m_status.height : m_config.height;
-        }
-
         // Render
         mpv_opengl_fbo fbo_params{
-            .fbo = fbo,
-            .w = width,
-            .h = height,
+            .fbo = static_cast<int>(target.fbo),
+            .w = static_cast<int>(target.width),
+            .h = static_cast<int>(target.height),
             .internal_format = 0  // Use default
         };
 
@@ -664,7 +681,7 @@ void MpvContext::renderLoop() {
 
         int result = mpv_render_context_render(m_renderCtx, params);
         if (result < 0) {
-            m_textureShare->releaseTexture();
+            m_textureShare->abandonRenderTarget();
             continue;
         }
 
@@ -673,10 +690,10 @@ void MpvContext::renderLoop() {
 
         // Flush GL commands to ensure rendering is complete before export.
         // macOS: glFlush is sufficient for GPU-to-GPU IOSurface sharing.
-        glFlush();
+        if (m_config.finishBeforeExport) glFinish();
+        else glFlush();
 
-        // Unlock and export texture
-        TextureInfo info = m_textureShare->unlockAndExport();
+        TextureInfo info = m_textureShare->exportRenderTarget();
         if (info.is_valid) {
             static int frameCount = 0;
             if (frameCount < 10) {
@@ -684,10 +701,6 @@ void MpvContext::renderLoop() {
                           << info.width << "x" << info.height << std::endl;
             }
             frameCount++;
-
-            std::lock_guard<std::mutex> lock(m_frameMutex);
-            m_currentFrame = info;
-            m_frameInUse = true;
 
             // Notify callback
             std::lock_guard<std::mutex> cbLock(m_callbackMutex);
@@ -720,7 +733,7 @@ void* MpvContext::getProcAddress(void* ctx, const char* name) {
 #elif defined(__APPLE__)
     return dlsym(RTLD_DEFAULT, name);
 #else
-    return reinterpret_cast<void*>(glXGetProcAddressARB(reinterpret_cast<const GLubyte*>(name)));
+    return g_linuxEglContext ? g_linuxEglContext->getProcAddress(name) : nullptr;
 #endif
 }
 

--- a/packages/mpv-texture/src/native/mpv_context.cpp
+++ b/packages/mpv-texture/src/native/mpv_context.cpp
@@ -653,7 +653,9 @@ void MpvContext::renderLoop() {
         }
         return;
     }
-    std::cout << "[MpvContext] EGL context made current in render thread" << std::endl;
+    if (m_config.debugLogging) {
+        std::cout << "[MpvContext] EGL context made current in render thread" << std::endl;
+    }
 #endif
 
     while (m_running) {
@@ -670,7 +672,9 @@ void MpvContext::renderLoop() {
             uint32_t newWidth = m_pendingWidth.load();
             uint32_t newHeight = m_pendingHeight.load();
             if (newWidth > 0 && newHeight > 0) {
-                std::cout << "[MpvContext] Resizing texture to " << newWidth << "x" << newHeight << std::endl;
+                if (m_config.debugLogging) {
+                    std::cout << "[MpvContext] Resizing texture to " << newWidth << "x" << newHeight << std::endl;
+                }
                 m_textureShare->resizeTexture(newWidth, newHeight);
             }
             m_needsResize = false;
@@ -685,7 +689,7 @@ void MpvContext::renderLoop() {
         RenderTarget target;
         if (!m_textureShare->acquireRenderTarget(target)) {
             static int lockFailCount = 0;
-            if (lockFailCount < 5) {
+            if (m_config.debugLogging && lockFailCount < 5) {
                 std::cout << "[MpvContext] No free texture slot; dropping frame" << std::endl;
                 lockFailCount++;
             }
@@ -724,7 +728,7 @@ void MpvContext::renderLoop() {
         TextureInfo info = m_textureShare->exportRenderTarget();
         if (info.is_valid) {
             static int frameCount = 0;
-            if (frameCount < 10) {
+            if (m_config.debugLogging && frameCount < 10) {
                 std::cout << "[MpvContext] Frame " << frameCount << " exported: "
                           << info.width << "x" << info.height << std::endl;
             }

--- a/packages/mpv-texture/src/native/mpv_context.h
+++ b/packages/mpv-texture/src/native/mpv_context.h
@@ -41,6 +41,10 @@ struct MpvConfig {
     uint32_t height = 1080;
     std::string hwdec = "auto";  // Hardware decoding: auto, d3d11va, videotoolbox, etc.
     std::string vo = "libmpv";   // Video output
+    uint32_t gpuVendorId = 0;
+    uint32_t gpuDeviceId = 0;
+    bool debugLogging = false;
+    bool finishBeforeExport = false;
 };
 
 class MpvContext {
@@ -68,7 +72,7 @@ public:
     void setErrorCallback(ErrorCallback callback);
 
     // Frame management
-    void releaseFrame();
+    void releaseFrame(uint32_t buffer_id);
 
     // Get current status
     MpvStatus getStatus() const;
@@ -110,11 +114,6 @@ private:
     std::atomic<bool> m_needsResize{false};
     std::atomic<uint32_t> m_pendingWidth{0};
     std::atomic<uint32_t> m_pendingHeight{0};
-
-    // Frame synchronization
-    std::mutex m_frameMutex;
-    std::atomic<bool> m_frameInUse{false};
-    TextureInfo m_currentFrame{};
 
     // Current state
     MpvStatus m_status{};

--- a/packages/mpv-texture/src/native/texture_share.h
+++ b/packages/mpv-texture/src/native/texture_share.h
@@ -1,67 +1,73 @@
 /*
- * Platform-agnostic texture sharing interface
- * Implementations: win32/dxgi_texture.cpp, macos/iosurface_texture.mm
+ * Platform texture-sharing seam.
+ * Implementations own buffer allocation, export metadata, and frame lifetime.
  */
 
 #ifndef TEXTURE_SHARE_H_
 #define TEXTURE_SHARE_H_
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace mpv_texture {
 
-// Texture format for shared textures
 enum class TextureFormat {
-    RGBA8,    // Standard RGBA
-    NV12,     // YUV 4:2:0 (hardware decode output)
-    BGRA8     // BGRA (macOS IOSurface native format)
+    RGBA8,
+    NV12,
+    BGRA8
 };
 
-// Information about an exported texture
+enum class TextureHandleType {
+    IOSurface,
+    NativePixmap,
+    NTHandle
+};
+
+struct NativePixmapPlane {
+    int fd = -1;
+    uint32_t stride = 0;
+    uint32_t offset = 0;
+    uint64_t size = 0;
+};
+
 struct TextureInfo {
-    uint64_t handle;        // Platform-specific handle (HANDLE on Win, IOSurfaceRef pointer on Mac)
-    uint32_t width;
-    uint32_t height;
-    TextureFormat format;
-    bool is_valid;
+    TextureHandleType handle_type = TextureHandleType::IOSurface;
+    uint64_t handle = 0;
+    uint32_t buffer_id = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    TextureFormat format = TextureFormat::RGBA8;
+    std::vector<NativePixmapPlane> planes;
+    std::string modifier;
+    bool supports_zero_copy_webgpu_import = false;
+    bool is_valid = false;
 };
 
-// Abstract interface for platform-specific texture sharing
+struct RenderTarget {
+    uint32_t fbo = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
+
 class ITextureShare {
 public:
     virtual ~ITextureShare() = default;
 
-    // Initialize the texture sharing system
-    // gl_context: Platform-specific GL context (HGLRC on Win, CGLContextObj on Mac)
     virtual bool initialize(void* gl_context) = 0;
-
-    // Create a shared texture of the given size
     virtual bool createTexture(uint32_t width, uint32_t height) = 0;
-
-    // Resize the shared texture
     virtual bool resizeTexture(uint32_t width, uint32_t height) = 0;
 
-    // Get the OpenGL texture ID for mpv to render into
-    virtual uint32_t getGLTexture() const = 0;
+    // Reserves a producer-owned slot. Returning false drops the incoming frame
+    // rather than blocking or overwriting a slot still owned by Electron.
+    virtual bool acquireRenderTarget(RenderTarget& target) = 0;
+    virtual TextureInfo exportRenderTarget() = 0;
+    virtual void abandonRenderTarget() = 0;
 
-    // Get the OpenGL FBO ID
-    virtual uint32_t getGLFBO() const = 0;
-
-    // Lock the texture for rendering (call before mpv_render_context_render)
-    virtual bool lockTexture() = 0;
-
-    // Unlock and export the texture (call after mpv_render_context_render)
-    // Returns the texture info for sharing with Electron
-    virtual TextureInfo unlockAndExport() = 0;
-
-    // Release a previously exported texture
-    virtual void releaseTexture() = 0;
-
-    // Clean up all resources
+    virtual void releaseTexture(uint32_t buffer_id) = 0;
     virtual void destroy() = 0;
 };
 
-// Factory function - implemented per platform
 ITextureShare* createTextureShare();
 
 } // namespace mpv_texture

--- a/packages/mpv-texture/src/native/win32/dxgi_texture.cpp
+++ b/packages/mpv-texture/src/native/win32/dxgi_texture.cpp
@@ -209,15 +209,7 @@ public:
         return createTexture(width, height);
     }
 
-    uint32_t getGLTexture() const override {
-        return m_slots[m_writeIndex].glTexture;
-    }
-
-    uint32_t getGLFBO() const override {
-        return m_slots[m_writeIndex].glFBO;
-    }
-
-    bool lockTexture() override {
+    bool acquireRenderTarget(RenderTarget& target) override {
         auto& slot = m_slots[m_writeIndex];
         if (!slot.wglDxObject) {
             std::cerr << "[DXGI] lockTexture: No DX object" << std::endl;
@@ -236,10 +228,13 @@ public:
         }
 
         m_locked = true;
+        target.fbo = slot.glFBO;
+        target.width = m_width;
+        target.height = m_height;
         return true;
     }
 
-    TextureInfo unlockAndExport() override {
+    TextureInfo exportRenderTarget() override {
         TextureInfo info = {};
 
         if (!m_locked) {
@@ -257,6 +252,7 @@ public:
         m_locked = false;
 
         // Export this slot's handle
+        info.handle_type = TextureHandleType::NTHandle;
         info.handle = reinterpret_cast<uint64_t>(slot.sharedHandle);
         info.width = m_width;
         info.height = m_height;
@@ -269,7 +265,15 @@ public:
         return info;
     }
 
-    void releaseTexture() override {
+    void abandonRenderTarget() override {
+        if (!m_locked) return;
+        auto& slot = m_slots[m_writeIndex];
+        HANDLE objects[] = { slot.wglDxObject };
+        m_wglDXUnlockObjectsNV(m_wglDxDevice, 1, objects);
+        m_locked = false;
+    }
+
+    void releaseTexture(uint32_t) override {
         // No-op with triple buffering - mpv always has a free slot to write to
     }
 

--- a/packages/ui/src/components/VideoCanvas.tsx
+++ b/packages/ui/src/components/VideoCanvas.tsx
@@ -56,6 +56,32 @@ interface WebGLState {
   flipXLocation: WebGLUniformLocation;
 }
 
+interface FrameCadenceStats {
+  startedAt: number;
+  lastFrameAt: number;
+  lastFrameIndex: number;
+  frames: number;
+  outOfOrder: number;
+  indexGaps: number;
+  intervals: number[];
+  drawMs: number;
+  maxDrawMs: number;
+}
+
+function createFrameCadenceStats(): FrameCadenceStats {
+  return {
+    startedAt: 0,
+    lastFrameAt: 0,
+    lastFrameIndex: -1,
+    frames: 0,
+    outOfOrder: 0,
+    indexGaps: 0,
+    intervals: [],
+    drawMs: 0,
+    maxDrawMs: 0,
+  };
+}
+
 function createShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader | null {
   const shader = gl.createShader(type);
   if (!shader) return null;
@@ -170,9 +196,10 @@ export function VideoCanvas({ visible, className, flipY = false, flipX = false }
   const glStateRef = useRef<WebGLState | null>(null);
   const drawErrorCount = useRef(0);
   const contextLostRef = useRef(false);
+  const cadenceRef = useRef<FrameCadenceStats>(createFrameCadenceStats());
 
   // Handle frame - render immediately
-  const handleFrame = useCallback((videoFrame: VideoFrame, _index: number) => {
+  const handleFrame = useCallback((videoFrame: VideoFrame, index: number) => {
     const canvas = canvasRef.current;
     const glState = glStateRef.current;
 
@@ -184,6 +211,17 @@ export function VideoCanvas({ visible, className, flipY = false, flipX = false }
     const { gl, program, texture, vao, flipYLocation, flipXLocation } = glState;
     const width = videoFrame.codedWidth;
     const height = videoFrame.codedHeight;
+    const frameAt = performance.now();
+    const cadence = cadenceRef.current;
+    if (cadence.startedAt === 0) cadence.startedAt = frameAt;
+    if (cadence.lastFrameAt > 0) cadence.intervals.push(frameAt - cadence.lastFrameAt);
+    if (cadence.lastFrameIndex >= 0) {
+      if (index <= cadence.lastFrameIndex) cadence.outOfOrder++;
+      else cadence.indexGaps += Math.max(0, index - cadence.lastFrameIndex - 1);
+    }
+    cadence.lastFrameAt = frameAt;
+    cadence.lastFrameIndex = index;
+    cadence.frames++;
 
     // Resize canvas if needed
     if (canvas.width !== width || canvas.height !== height) {
@@ -194,6 +232,7 @@ export function VideoCanvas({ visible, className, flipY = false, flipX = false }
     }
 
     // Draw
+    const drawStartedAt = performance.now();
     try {
       gl.bindTexture(gl.TEXTURE_2D, texture);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, videoFrame);
@@ -214,6 +253,26 @@ export function VideoCanvas({ visible, className, flipY = false, flipX = false }
           window.debug?.logFromRenderer(`[VideoCanvas] Draw error (${count} total): ${e}`);
         }
       }
+    }
+    const drawMs = performance.now() - drawStartedAt;
+    cadence.drawMs += drawMs;
+    cadence.maxDrawMs = Math.max(cadence.maxDrawMs, drawMs);
+
+    if (frameAt - cadence.startedAt >= 2000) {
+      const intervals = [...cadence.intervals].sort((left, right) => left - right);
+      const percentile = (value: number) => intervals[Math.min(intervals.length - 1, Math.floor(intervals.length * value))] ?? 0;
+      const avgDraw = cadence.frames > 0 ? cadence.drawMs / cadence.frames : 0;
+      void window.debug?.logFromRenderer(
+        `[VideoCanvas] cadence frames:${cadence.frames} gaps:${cadence.indexGaps} reverse:${cadence.outOfOrder} ` +
+        `interval p50/p95/max:${percentile(0.5).toFixed(1)}/${percentile(0.95).toFixed(1)}/${percentile(1).toFixed(1)}ms ` +
+        `draw avg/max:${avgDraw.toFixed(1)}/${cadence.maxDrawMs.toFixed(1)}ms`
+      );
+      cadenceRef.current = {
+        ...createFrameCadenceStats(),
+        startedAt: frameAt,
+        lastFrameAt: frameAt,
+        lastFrameIndex: index,
+      };
     }
 
     videoFrame.close();

--- a/packages/ui/src/components/VideoCanvas.tsx
+++ b/packages/ui/src/components/VideoCanvas.tsx
@@ -241,6 +241,7 @@ export function VideoCanvas({ visible, className, flipY = false, flipX = false }
       gl.uniform1i(flipXLocation, flipX ? 1 : 0);
       gl.bindVertexArray(vao);
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+      gl.flush();
     } catch (e) {
       drawErrorCount.current++;
       const count = drawErrorCount.current;


### PR DESCRIPTION
On Linux, video now plays inside the Electron instead of opening a separate floating mpv window. Works on both Wayland and X11.

### Changes

- Added Linux native addon building and packaging.
- Added the required EGL, GBM, DRM, OpenGL, and libmpv dependencies.
- Added playback diagnostics for frame timing and buffer usage.
- Kept the existing macOS and Windows implementations working.

### How It Works

1. libmpv decodes and renders each video frame using OpenGL.
2. The native addon stores the frame in a direct memory access buffer (`DMA-BUF`).
3. Electron imports that buffer as a shared texture.
4. `VideoCanvas` draws the texture inside the app.
5. Electron tells the native addon when it is finished with the buffer so it can be reused.

Four buffers are rotated between mpv and Electron. This keeps rendering smooth when Electron takes longer to release a frame. If playback becomes choppy on other hardware, adjusting the buffer count is a good first place to look.

The app also detects which GPU Chromium is actually using to avoid hybrid GPU shenanigans.

### Fallback Behavior

The app offers compatibility mode, which uses an external mpv window like before. Compatibility mode only lasts for that launch. The next normal launch tries native rendering again.