### PR TITLE
ci: patch electron-builder keychain password for macos-26.6 runners

### DIFF
--- a/patches/app-builder-lib@26.4.0.patch
+++ b/patches/app-builder-lib@26.4.0.patch
@@ -1,0 +1,26 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 17e0c1e7be271b7bce8a7671bfe9d0760a0c9f9a..ee6ae9805c87139957098f3e980645c48a1e49d2 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -157,16 +157,18 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIK
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        // `-k` takes the keychain's own unlock password (from create-keychain above), not the
++        // imported item's password. macOS 26.6+ validates this; upstream fix: electron-builder 26.16.1.
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  app-builder-lib@26.4.0:
+    hash: 57a31eda1734980594afda7c9df480ef7c860ba471b54128aa714e19449e877f
+    path: patches/app-builder-lib@26.4.0.patch
+
 importers:
 
   .:
@@ -3206,7 +3211,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0):
+  app-builder-lib@26.4.0(patch_hash=57a31eda1734980594afda7c9df480ef7c860ba471b54128aa714e19449e877f)(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -3535,7 +3540,7 @@ snapshots:
 
   dmg-builder@26.4.0(electron-builder-squirrel-windows@26.4.0):
     dependencies:
-      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
+      app-builder-lib: 26.4.0(patch_hash=57a31eda1734980594afda7c9df480ef7c860ba471b54128aa714e19449e877f)(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
       builder-util: 26.3.4
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -3582,7 +3587,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.4.0(dmg-builder@26.4.0):
     dependencies:
-      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
+      app-builder-lib: 26.4.0(patch_hash=57a31eda1734980594afda7c9df480ef7c860ba471b54128aa714e19449e877f)(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
       builder-util: 26.3.4
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -3591,7 +3596,7 @@ snapshots:
 
   electron-builder@26.4.0(electron-builder-squirrel-windows@26.4.0):
     dependencies:
-      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
+      app-builder-lib: 26.4.0(patch_hash=57a31eda1734980594afda7c9df480ef7c860ba471b54128aa714e19449e877f)(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
       builder-util: 26.3.4
       builder-util-runtime: 9.5.1
       chalk: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
-  - 'packages/*'
+  - packages/*
+
+patchedDependencies:
+  app-builder-lib@26.4.0: patches/app-builder-lib@26.4.0.patch


### PR DESCRIPTION
macOS builds on `macos-latest` started failing at the code-signing step:

```
security set-key-partition-list -S apple-tool:,apple: -s -k *** <tmp>.keychain
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

**Cause.** app-builder-lib 26.4.0 passes the `.p12` certificate password as the keychain password to that command. Older macOS ignored the mismatch because the temporary keychain was already unlocked; the `macos-26-arm64` image 20260831 (macOS 26.6.2) validates it. The pool currently serves both 20260728 and 20260831, so mac legs fail at random. Tracked upstream as electron-userland/electron-builder#10066; fixed in electron-builder 26.16.1 (published 2026-09-07 on the `v26` dist-tag, not `latest`).

This affects the release pipeline too, not just PR test builds.

**Change.** A pnpm patch applying the same two-line fix to the pinned 26.4.0, so nothing else in the packager moves. Remove `patches/app-builder-lib@26.4.0.patch` and the `patchedDependencies` entry when electron-builder is bumped deliberately (with the usual auto-updater verification).

Not the secrets: a wrong `MAC_CERTS_PASSWORD` fails one command earlier at `security import` with a different message, and the `***` masking on `-k` shows the secret value is exactly what was being passed. Not an expired Apple agreement: that surfaces later as a notarization 403.

**Verification.** `pnpm install --frozen-lockfile --ignore-scripts` applies the patch; the installed `macCodeSign.js` shows `"-k", keychainPassword`. build-test dispatched on this branch; the mac job log's "Runner Image" version says whether it landed on the 20260831 image, which is the one that reproduces the failure.
